### PR TITLE
add workround for unreliable port availability logic

### DIFF
--- a/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
@@ -116,8 +116,9 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 }
                 catch (HttpListenerException)
                 {
-                    // For unknown reasons, sometimes the logic used in FindNextPort will return a port that's
-                    // not really available after all
+                    // Ssometimes the logic used in FindNextPort will return a port that's not really available after
+                    // all-- possibly due to a delay in cleaning up the temporary listener that FindNextPort creates.
+                    // There's not a great solution for this as far as I know, we just have to try another port.
                     port++;
                     continue;
                 }

--- a/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
@@ -106,37 +106,50 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         {
             var port = FindNextPort();
 
-            var listener = new HttpListener();
-            listener.Prefixes.Add(string.Format("http://*:{0}/", port));
-            listener.Start();
-            Task.Run(async () =>
+            while (true)
             {
-                while (!cancellationToken.IsCancellationRequested && listener.IsListening)
+                var listener = new HttpListener();
+                listener.Prefixes.Add(string.Format("http://*:{0}/", port));
+                try
                 {
-                    try
+                    listener.Start();
+                }
+                catch (HttpListenerException)
+                {
+                    // For unknown reasons, sometimes the logic used in FindNextPort will return a port that's
+                    // not really available after all
+                    port++;
+                    continue;
+                }
+                Task.Run(async () =>
+                {
+                    while (!cancellationToken.IsCancellationRequested && listener.IsListening)
                     {
-                        var listenerCtx = await listener.GetContextAsync().ConfigureAwait(false);
-                        var ctx = RequestContextImpl.FromHttpListenerContext(listenerCtx, cancellationToken);
+                        try
+                        {
+                            var listenerCtx = await listener.GetContextAsync().ConfigureAwait(false);
+                            var ctx = RequestContextImpl.FromHttpListenerContext(listenerCtx, cancellationToken);
 #pragma warning disable CS4014 // deliberately not awaiting this async task
                         Task.Run(async () =>
-                        {
-                            await Dispatch(ctx, rootHandler);
-                            listenerCtx.Response.Close();
-                        });
+                            {
+                                await Dispatch(ctx, rootHandler);
+                                listenerCtx.Response.Close();
+                            });
 #pragma warning restore CS4014
 
                     }
-                    catch
-                    {
+                        catch
+                        {
                         // an exception almost certainly means the listener has been shut down
                         break;
+                        }
                     }
-                }
-            });
+                });
 
-            serverUriOut = new Uri(string.Format("http://localhost:{0}/", port));
+                serverUriOut = new Uri(string.Format("http://localhost:{0}/", port));
 
-            return listener;
+                return listener;
+            }
         }
 
         private static int FindNextPort()


### PR DESCRIPTION
I had previously added a try/catch for a known issue where a "port already in use" exception would happen due to a delay in the port becoming available after a listener had been closed, but I found another place where this could happen. Failures were very rare but could have caused test flakiness in other libraries' tests that use this library.