### PR TITLE
allow charset to be omitted from Content-Type

### DIFF
--- a/src/LaunchDarkly.TestHelpers/HttpTest/Handlers.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/Handlers.cs
@@ -110,7 +110,8 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         /// </summary>
         /// <param name="contentType">response content type (used only if body is not null)</param>
         /// <param name="body">response body (may be null)</param>
-        /// <param name="encoding">response encoding (defaults to UTF8)</param>
+        /// <param name="encoding">character encoding; if not specified, no charset will be included
+        /// in the Content-Type header, but UTF8 will be used to encode the string</param>
         /// <returns>a <see cref="Handler"/></returns>
         /// <seealso cref="Body(string, byte[])"/>
         /// <seealso cref="BodyJson(string, Encoding)"/>
@@ -142,7 +143,8 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         /// </code>
         /// </example>
         /// <param name="contentType">the content type</param>
-        /// <param name="encoding">response encoding (defaults to UTF8)</param>
+        /// <param name="encoding">character encoding to include in the Content-Type header;
+        /// if not specified, Content-Type will not specify an encoding</param>
         /// <returns>a <see cref="Handler"/></returns>
         /// <seealso cref="WriteChunk(byte[])"/>
         /// <seealso cref="WriteChunkString(string, Encoding)"/>
@@ -167,7 +169,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         /// Creates a <see cref="Handler"/> that writes a chunk of response data.
         /// </summary>
         /// <param name="data">the chunk data as a string</param>
-        /// <param name="encoding">response encoding (defaults to UTF8)</param>
+        /// <param name="encoding">character encoding to use for this chunk (defaults to UTF8)</param>
         /// <returns>a <see cref="Handler"/></returns>
         /// <seealso cref="StartChunks(string, Encoding)"/>
         /// <seealso cref="WriteChunk(byte[])"/>
@@ -274,10 +276,11 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         public static class SSE
         {
             /// <summary>
-            /// Starts a chunked stream with the standard content type "text/event-stream.
+            /// Starts a chunked stream with the standard content type "text/event-stream",
+            /// and the charset UTF-8.
             /// </summary>
             /// <returns>a <see cref="Handler"/></returns>
-            public static Handler Start() => StartChunks("text/event-stream");
+            public static Handler Start() => StartChunks("text/event-stream", Encoding.UTF8);
 
             /// <summary>
             /// Writes an SSE comment line.
@@ -310,7 +313,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         }
 
         private static string ContentTypeWithEncoding(string contentType, Encoding encoding) =>
-            contentType is null || contentType.Contains("charset=") ? contentType :
-                contentType + "; charset=" + (encoding ?? Encoding.UTF8).WebName;
+            contentType is null || encoding is null || contentType.Contains("charset=") ? contentType :
+                contentType + "; charset=" + encoding.WebName;
     }
 }

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/HandlersTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/HandlersTest.cs
@@ -108,10 +108,23 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         }
 
         [Fact]
-        public async Task BodyString()
+        public async Task BodyStringWithNoCharsetInHeader()
         {
             string body = "hello";
             await WithServerAndClient(Handlers.BodyString("text/weird", body), async (server, client) =>
+            {
+                var resp = await client.GetAsync(server.Uri);
+                Assert.Equal(200, (int)resp.StatusCode);
+                AssertHeader(resp, "content-type", "text/weird");
+                Assert.Equal(body, await resp.Content.ReadAsStringAsync());
+            });
+        }
+
+        [Fact]
+        public async Task BodyStringWithCharsetInHeader()
+        {
+            string body = "hello";
+            await WithServerAndClient(Handlers.BodyString("text/weird", body, Encoding.UTF8), async (server, client) =>
             {
                 var resp = await client.GetAsync(server.Uri);
                 Assert.Equal(200, (int)resp.StatusCode);
@@ -121,9 +134,21 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         }
 
         [Fact]
-        public async Task BodyJson()
+        public async Task BodyJsonWithoutCharsetInHeader()
         {
             await WithServerAndClient(Handlers.BodyJson("true"), async (server, client) =>
+            {
+                var resp = await client.GetAsync(server.Uri);
+                Assert.Equal(200, (int)resp.StatusCode);
+                AssertHeader(resp, "content-type", "application/json");
+                Assert.Equal("true", await resp.Content.ReadAsStringAsync());
+            });
+        }
+
+        [Fact]
+        public async Task BodyJsonWithCharsetInHeader()
+        {
+            await WithServerAndClient(Handlers.BodyJson("true", Encoding.UTF8), async (server, client) =>
             {
                 var resp = await client.GetAsync(server.Uri);
                 Assert.Equal(200, (int)resp.StatusCode);
@@ -145,7 +170,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 Assert.Equal(201, (int)resp.StatusCode);
                 AssertHeader(resp, "name1", "value1");
                 AssertHeader(resp, "name2", "value2");
-                AssertHeader(resp, "content-type", "text/plain; charset=utf-8");
+                AssertHeader(resp, "content-type", "text/plain");
                 Assert.Equal("hello", await resp.Content.ReadAsStringAsync());
             });
         }

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/StreamingTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/StreamingTest.cs
@@ -11,11 +11,24 @@ namespace LaunchDarkly.TestHelpers.HttpTest
     public class StreamingTest
     {
         [Fact]
-        public async Task BasicChunkedResponse()
+        public async Task BasicChunkedResponseWithNoCharsetInHeader()
         {
             string[] chunks = new string[] { "first.", "second.", "third" };
             await DoStreamingTest(
                 Handlers.StartChunks("text/plain"),
+                chunks.Select(c => Handlers.WriteChunkString(c)).ToArray(),
+                Handlers.Hang(),
+                "text/plain",
+                chunks
+                );
+        }
+
+        [Fact]
+        public async Task BasicChunkedResponseWithCharsetInHeader()
+        {
+            string[] chunks = new string[] { "first.", "second.", "third" };
+            await DoStreamingTest(
+                Handlers.StartChunks("text/plain", Encoding.UTF8),
                 chunks.Select(c => Handlers.WriteChunkString(c)).ToArray(),
                 Handlers.Hang(),
                 "text/plain; charset=utf-8",


### PR DESCRIPTION
This fixes some undesirable defaulting behavior, to allow more control over a test HTTP server's responses.

Specifically: if the `encoding` parameter to `Handlers.BodyString`, `Handlers.BodyJson`, or `Handlers.StartChunks` is null or omitted, it will still default to using UTF8 encoding to encode the string (since we need to use _something_ to encode the string), but it will _not_ add `charset=utf-8` to the content type header. This is necessary in order to test client code that is supposed to have some particular behavior for "charset was specified" vs. "charset was not specified" (such as `dotnet-eventsource`). Any library for HTTP client testing ought to allow any valid HTTP response to be constructed, and it is valid in HTTP to omit the charset from the content type.