### PR TITLE
add some non-HTTP generic helper types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,6 @@ workflows:
   version: 2
   test:
     jobs:
-      # Even though LaunchDarkly.TestHelpers only has two build targets-- .NET Standard 2.0
-      # and .NET Framework 4.5.2-- we run the tests in a variety of runtime platforms. That's
-      # because there can be subtle differences in how APIs like System.Net.HttpListener
-      # behave across platforms, so we want to make sure these tools work consistently in all
-      # of them. The oldest one, .NET Core 2.0, is no longer a supported platform in current
-      # LaunchDarkly tools; we still test it because in some of our projects, .NET Core 2.0
-      # might be the only way to specifically test the .NET Standard 2.0 implementation of a
-      # package (e.g. if there is also a different build target for .NET Core 2.1).
-      - test-netcore:
-          name: .NET Core 2.0
-          docker-image: microsoft/dotnet:2.0-sdk-jessie
-          test-target-framework: netcoreapp2.0
       - test-netcore:
           name: .NET Core 2.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal

--- a/docs-src/namespaces/LaunchDarkly.TestHelpers.md
+++ b/docs-src/namespaces/LaunchDarkly.TestHelpers.md
@@ -1,0 +1,3 @@
+General-purpose helper types.
+
+This namespace provides generic tools such as <xref:LaunchDarkly.TestHelpers.BuilderBehavior> and <xref:LaunchDarkly.TestHelpers.TypeBehavior>.

--- a/src/LaunchDarkly.TestHelpers/Assertions.cs
+++ b/src/LaunchDarkly.TestHelpers/Assertions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LaunchDarkly.TestHelpers
+{
+    /// <summary>
+    /// Miscellaneous Xunit helpers.
+    /// </summary>
+    public static class Assertions
+    {
+        /// <summary>
+        /// Polls a function repeatedly until it returns true, failing if it times out.
+        /// </summary>
+        /// <param name="timeout">the maximum time to wait</param>
+        /// <param name="interval">the interval to poll at</param>
+        /// <param name="test">the function to test</param>
+        public static void AssertEventually(TimeSpan timeout, TimeSpan interval, Func<bool> test)
+        {
+            var deadline = DateTime.Now.Add(timeout);
+            while (DateTime.Now < deadline)
+            {
+                if (test())
+                {
+                    return;
+                }
+                Thread.Sleep(interval);
+            }
+            Assert.True(false, "timed out before test condition was satisfied");
+        }
+
+        /// <summary>
+        /// Polls a function repeatedly until it returns true, failing if it times out.
+        /// </summary>
+        /// <param name="timeout">the maximum time to wait</param>
+        /// <param name="interval">the interval to poll at</param>
+        /// <param name="test">the function to test</param>
+        public static async Task AssertEventuallyAsync(TimeSpan timeout, TimeSpan interval, Func<Task<bool>> test)
+        {
+            var deadline = DateTime.Now.Add(timeout);
+            while (DateTime.Now < deadline)
+            {
+                if (await test())
+                {
+                    return;
+                }
+                await Task.Delay(interval);
+            }
+            Assert.True(false, "timed out before test condition was satisfied");
+        }
+    }
+}

--- a/src/LaunchDarkly.TestHelpers/BuilderBehavior.cs
+++ b/src/LaunchDarkly.TestHelpers/BuilderBehavior.cs
@@ -1,0 +1,281 @@
+﻿using System;
+using Xunit;
+
+namespace LaunchDarkly.TestHelpers
+{
+    /// <summary>
+    /// Factories for helper classes that provide useful test patterns for builder types.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These helpers make it easier to provide thorough test coverage of builder types.
+    /// It is easy when implementing builders to make basic mistakes like not setting the
+    /// right property in a setter, not enforcing desired constraints, or not copying all
+    /// the properties in a copy constructor.
+    /// </para>
+    /// <para>
+    /// The general pattern consists of creating a generic helper for the builder type and
+    /// the type that it builds, then creating a property helper for each settable property
+    /// and performing standard assertions with it. Example:
+    /// </para>
+    /// <pre><code>
+    ///     // This assumes there is a type MyBuilder whose Build method creates an
+    ///     // instance of MyType, with properties Height and Weight.
+    ///     
+    ///     var tester = BuilderBehavior.For(() => new MyBuilder(), b => b.Build());
+    ///
+    ///     var height = tester.Property(x => x.Height, b => (b, value) => b.Height(value));
+    ///     height.AssertDefault(DefaultHeight);
+    ///     height.AssertCanSet(72);
+    ///     height.AssertSetIsChangedTo(-1, 0); // setter should enforce minimum height of 0
+    ///
+    ///     var weight = tester.Property(x => x.Weight, b => (b, value) => b.Weight(value));
+    ///     weight.AssertDefault(DefaultWeight);
+    ///     weight.AssertCanSet(200);
+    ///     weight.AssertSetIsChangedTo(-1, 0); // setter should enforce minimum weight of 0
+    /// </code></pre>
+    /// <para>
+    /// It uses Xunit assertion methods.
+    /// </para>
+    /// </remarks>
+    public static class BuilderBehavior
+    {
+        /// <summary>
+        /// Provides a generic <see cref="BuildTester{TBuilder, TBuilt}"/> for testing
+        /// methods of a builder against properties of the type it builds.
+        /// </summary>
+        /// <typeparam name="TBuilder">the builder type</typeparam>
+        /// <typeparam name="TBuilt">the type that it builds</typeparam>
+        /// <param name="constructor">function that constructs a <typeparamref name="TBuilder"/></param>
+        /// <param name="buildMethod">function that creates a <typeparamref name="TBuilt"/>
+        ///   from a <typeparamref name="TBuilder"/></param>
+        /// <returns>a <see cref="BuilderBehavior.BuildTester{TBuilder, TBuilt}"/> instance</returns>
+        public static BuildTester<TBuilder, TBuilt> For<TBuilder, TBuilt>(
+            Func<TBuilder> constructor, Func<TBuilder, TBuilt> buildMethod) =>
+            new BuildTester<TBuilder, TBuilt>(constructor, buildMethod, null);
+
+        /// <summary>
+        /// Provides a generic <see cref="InternalStateTester{TBuilder}"/> for testing
+        /// methods of a builder against the builder's own internal state.
+        /// </summary>
+        /// <remarks>
+        /// This can be used in cases where it is not feasible for the test code to actually
+        /// call the builder's build method, for instance if it has unwanted side effects.
+        /// </remarks>
+        /// <typeparam name="TBuilder">the builder type</typeparam>
+        /// <param name="constructor">function that constructs a <typeparamref name="TBuilder"/></param>
+        /// <returns>an <see cref="InternalStateTester{TBuilder}"/> instance</returns>
+        // Use this when we want to test the builder's internal state directly, without
+        // calling Build - i.e. if the object is difficult to inspect after it's built.
+        public static InternalStateTester<TBuilder> For<TBuilder>(Func<TBuilder> constructor) =>
+            new InternalStateTester<TBuilder>(constructor);
+
+        /// <summary>
+        /// Helper class that provides useful test patterns for a builder type and the
+        /// type that it builds.
+        /// </summary>
+        /// <remarks>
+        /// Create instances of this class with
+        /// <see cref="BuilderBehavior.For{TBuilder, TBuilt}(Func{TBuilder}, Func{TBuilder, TBuilt})"/>.
+        /// </remarks>
+        /// <typeparam name="TBuilder">the builder type</typeparam>
+        /// <typeparam name="TBuilt">the type that it builds</typeparam>
+        public sealed class BuildTester<TBuilder, TBuilt>
+        {
+            private readonly Func<TBuilder> _constructor;
+            internal readonly Func<TBuilder, TBuilt> _buildMethod;
+            internal readonly Func<TBuilt, TBuilder> _copyConstructor;
+
+            internal BuildTester(Func<TBuilder> constructor,
+                Func<TBuilder, TBuilt> buildMethod,
+                Func<TBuilt, TBuilder> copyConstructor
+                )
+            {
+                _constructor = constructor;
+                _buildMethod = buildMethod;
+                _copyConstructor = copyConstructor;
+            }
+
+            /// <summary>
+            /// Creates a helper for testing a specific property of the builder.
+            /// </summary>
+            /// <typeparam name="TValue">type of the property</typeparam>
+            /// <param name="getter">function that gets that property from the built object</param>
+            /// <param name="builderSetter">function that sets the property in the builder</param>
+            /// <returns></returns>
+            public IPropertyAssertions<TValue> Property<TValue>(
+                Func<TBuilt, TValue> getter,
+                Action<TBuilder, TValue> builderSetter
+                ) =>
+            new BuildTesterProperty<TBuilder, TBuilt, TValue>(
+                this, getter, builderSetter);
+
+            /// <summary>
+            /// Creates an instance of the builder.
+            /// </summary>
+            /// <returns>a new instance</returns>
+            public TBuilder New() => _constructor();
+
+            /// <summary>
+            /// Adds the ability to test the builder's copy constructor.
+            /// </summary>
+            /// <remarks>
+            /// The effect of this is that all <see cref="Property{TValue}(Func{TBuilt, TValue}, Action{TBuilder, TValue})"/>
+            /// assertions created from the resulting helper will also verify that copying
+            /// the builder also copies the value of this property.
+            /// </remarks>
+            /// <param name="copyConstructor">function that should create a new builder with an
+            ///   identical state to the existing one</param>
+            /// <returns>a copy of the <c>BuilderTestHelper</c> with this additional behavior</returns>
+            public BuildTester<TBuilder, TBuilt> WithCopyConstructor(
+                Func<TBuilt, TBuilder> copyConstructor
+                ) =>
+                new BuildTester<TBuilder, TBuilt>(_constructor, _buildMethod, copyConstructor);
+        }
+
+        /// <summary>
+        /// Similar to <see cref="BuildTester{TBuilder, TBuilt}"/>, but instead of testing the values of
+        /// properties in the built object, it inspects the builder directly.
+        /// </summary>
+        /// <remarks>
+        /// Create instances of this class with <see cref="BuilderBehavior.For{TBuilder}(Func{TBuilder})"/>.
+        /// </remarks>
+        /// <typeparam name="TBuilder">the builder type</typeparam>
+        public class InternalStateTester<TBuilder>
+        {
+            private readonly Func<TBuilder> _constructor;
+
+            internal InternalStateTester(Func<TBuilder> constructor)
+            {
+                _constructor = constructor;
+            }
+
+            /// <summary>
+            /// Creates a helper for testing a specific property of the builder.
+            /// </summary>
+            /// <typeparam name="TValue">type of the property</typeparam>
+            /// <param name="builderGetter">function that gets that property from the builder's internal state</param>
+            /// <param name="builderSetter">function that sets the property in the builder</param>
+            /// <returns></returns>
+            public IPropertyAssertions<TValue> Property<TValue>(
+                Func<TBuilder, TValue> builderGetter,
+                Action<TBuilder, TValue> builderSetter
+                ) =>
+                new InternalStateTesterProperty<TBuilder, TValue>(this,
+                    builderGetter, builderSetter);
+
+            /// <summary>
+            /// Creates an instance of the builder.
+            /// </summary>
+            /// <returns>a new instance</returns>
+            public TBuilder New() => _constructor();
+        }
+
+        /// <summary>
+        /// Assertions provided by the property-specific helpers.
+        /// </summary>
+        /// <typeparam name="TValue">type of the property</typeparam>
+        public interface IPropertyAssertions<TValue>
+        {
+            /// <summary>
+            /// Asserts that the property has the expected value when it has not been set.
+            /// </summary>
+            /// <param name="defaultValue">the expected value</param>
+            void AssertDefault(TValue defaultValue);
+
+            /// <summary>
+            /// Asserts that calling the setter for a specific value causes the property
+            /// to have that value.
+            /// </summary>
+            /// <param name="newValue">the expected value</param>
+            void AssertCanSet(TValue newValue);
+
+            /// <summary>
+            /// Asserts that calling the setter for a specific value causes the property
+            /// to have another specific value for the corresponding property.
+            /// </summary>
+            /// <param name="attemptedValue">the value to pass to the setter</param>
+            /// <param name="resultingValue">the expected result value</param>
+            void AssertSetIsChangedTo(TValue attemptedValue, TValue resultingValue);
+        }
+
+        internal class BuildTesterProperty<TBuilder, TBuilt, TValue> : IPropertyAssertions<TValue>
+        {
+            private readonly BuildTester<TBuilder, TBuilt> _owner;
+            private readonly Func<TBuilt, TValue> _getter;
+            private readonly Action<TBuilder, TValue> _builderSetter;
+
+            internal BuildTesterProperty(BuildTester<TBuilder, TBuilt> owner,
+                Func<TBuilt, TValue> getter,
+                Action<TBuilder, TValue> builderSetter)
+            {
+                _owner = owner;
+                _getter = getter;
+                _builderSetter = builderSetter;
+            }
+
+            public void AssertDefault(TValue defaultValue)
+            {
+                var b = _owner.New();
+                AssertValue(b, defaultValue);
+            }
+
+            public void AssertCanSet(TValue newValue)
+            {
+                AssertSetIsChangedTo(newValue, newValue);
+            }
+
+            public void AssertSetIsChangedTo(TValue attemptedValue, TValue resultingValue)
+            {
+                var b = _owner.New();
+                _builderSetter(b, attemptedValue);
+                AssertValue(b, resultingValue);
+            }
+
+            private void AssertValue(TBuilder b, TValue v)
+            {
+                var o = _owner._buildMethod(b);
+                Assert.Equal(v, _getter(o));
+                if (_owner._copyConstructor != null)
+                {
+                    var b1 = _owner._copyConstructor(o);
+                    var o1 = _owner._buildMethod(b);
+                    Assert.Equal(v, _getter(o));
+                }
+            }
+        }
+
+        internal class InternalStateTesterProperty<TBuilder, TValue> : IPropertyAssertions<TValue>
+        {
+            private readonly InternalStateTester<TBuilder> _owner;
+            private readonly Func<TBuilder, TValue> _builderGetter;
+            private readonly Action<TBuilder, TValue> _builderSetter;
+
+            internal InternalStateTesterProperty(InternalStateTester<TBuilder> owner,
+                Func<TBuilder, TValue> builderGetter,
+                Action<TBuilder, TValue> builderSetter)
+            {
+                _owner = owner;
+                _builderGetter = builderGetter;
+                _builderSetter = builderSetter;
+            }
+
+            public void AssertDefault(TValue defaultValue)
+            {
+                Assert.Equal(defaultValue, _builderGetter(_owner.New()));
+            }
+
+            public void AssertCanSet(TValue newValue)
+            {
+                AssertSetIsChangedTo(newValue, newValue);
+            }
+
+            public void AssertSetIsChangedTo(TValue attemptedValue, TValue resultingValue)
+            {
+                var b = _owner.New();
+                _builderSetter(b, attemptedValue);
+                Assert.Equal(resultingValue, _builderGetter(b));
+            }
+        }
+    }
+}

--- a/src/LaunchDarkly.TestHelpers/BuilderBehavior.cs
+++ b/src/LaunchDarkly.TestHelpers/BuilderBehavior.cs
@@ -239,8 +239,8 @@ namespace LaunchDarkly.TestHelpers
                 if (_owner._copyConstructor != null)
                 {
                     var b1 = _owner._copyConstructor(o);
-                    var o1 = _owner._buildMethod(b);
-                    Assert.Equal(v, _getter(o));
+                    var o1 = _owner._buildMethod(b1);
+                    Assert.Equal(v, _getter(o1));
                 }
             }
         }

--- a/src/LaunchDarkly.TestHelpers/EventSink.cs
+++ b/src/LaunchDarkly.TestHelpers/EventSink.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Xunit;
+
+namespace LaunchDarkly.TestHelpers
+{
+    /// <summary>
+    /// A synchronous blocking queue with Xunit assertion helpers.
+    /// </summary>
+    /// <typeparam name="T">the type of items in the queue</typeparam>
+    public sealed class EventSink<T>
+    {
+        private readonly BlockingCollection<T> _queue = new BlockingCollection<T>();
+
+        /// <summary>
+        /// Equivalent to <see cref="Enqueue(T)"/>, but with a first <c>sender</c> parameter so it
+        /// can be used as an event handler.
+        /// </summary>
+        /// <param name="sender">the event sender</param>
+        /// <param name="args">the event data</param>
+        public void Add(object sender, T args) => Enqueue(args);
+
+        /// <summary>
+        /// Adds a value to the queue.
+        /// </summary>
+        /// <param name="arg">the value</param>
+        public void Enqueue(T arg) => _queue.Add(arg);
+
+        /// <summary>
+        /// Equivalent to <see cref="ExpectValue(TimeSpan)"/> with a timeout of one second.
+        /// </summary>
+        /// <returns>the received value</returns>
+        public T ExpectValue() => ExpectValue(TimeSpan.FromSeconds(1));
+
+        /// <summary>
+        /// Takes a value from the queue and returns it, or causes an assertion failure if the timeout
+        /// expires.
+        /// </summary>
+        /// <param name="timeout">how long to wait for an item</param>
+        /// <returns>the item</returns>
+        public T ExpectValue(TimeSpan timeout)
+        {
+            Assert.True(_queue.TryTake(out var value, timeout), "expected an event but did not get one");
+            return value;
+        }
+
+        /// <summary>
+        /// Takes a value from the queue if one exists.
+        /// </summary>
+        /// <param name="value">receives the value</param>
+        /// <returns>true if successful</returns>
+        public bool TryTakeValue(out T value) => _queue.TryTake(out value, TimeSpan.FromSeconds(1));
+
+        /// <summary>
+        /// Equivalent to <see cref="ExpectNoValue(TimeSpan)"/> with a timeout of 100 milliseconds.
+        /// </summary>
+        public void ExpectNoValue() => ExpectNoValue(TimeSpan.FromMilliseconds(100));
+
+        /// <summary>
+        /// Causes an assertion failure if the queue contains any items.
+        /// </summary>
+        /// <param name="timeout">how long to wait</param>
+        public void ExpectNoValue(TimeSpan timeout) =>
+            Assert.False(_queue.TryTake(out _, timeout), "expected no event but got one");
+    }
+}

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -24,6 +24,12 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.3.1" />
+  </ItemGroup>
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.TestHelpers.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/LaunchDarkly.TestHelpers/TypeBehavior.cs
+++ b/src/LaunchDarkly.TestHelpers/TypeBehavior.cs
@@ -1,15 +1,21 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using Xunit;
 
 namespace LaunchDarkly.TestHelpers
 {
     /// <summary>
-    /// Test assertions that may be helpful in testing generic type behavior.
+    /// Xunit test assertions that may be helpful in testing generic type behavior.
     /// </summary>
     public static class TypeBehavior
     {
+        /// <summary>
+        /// Asserts that the values are commutatively equal with Equal(), and that their hash
+        /// codes are equal.
+        /// </summary>
+        /// <typeparam name="T">the type of the values</typeparam>
+        /// <param name="a">a value</param>
+        /// <param name="b">another value</param>
         public static void AssertEqual<T>(T a, T b)
         {
             Assert.Equal(a, b);
@@ -17,6 +23,13 @@ namespace LaunchDarkly.TestHelpers
             Assert.Equal(a.GetHashCode(), b.GetHashCode());
         }
 
+        /// <summary>
+        /// Asserts that the values are commutatively unequal with Equal(). The hash codes do not
+        /// have to be unequal.
+        /// </summary>
+        /// <typeparam name="T">the type of the values</typeparam>
+        /// <param name="a">a value</param>
+        /// <param name="b">another value</param>
         public static void AssertNotEqual<T>(T a, T b)
         {
             Assert.NotEqual(a, b);

--- a/src/LaunchDarkly.TestHelpers/TypeBehavior.cs
+++ b/src/LaunchDarkly.TestHelpers/TypeBehavior.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace LaunchDarkly.TestHelpers
+{
+    /// <summary>
+    /// Test assertions that may be helpful in testing generic type behavior.
+    /// </summary>
+    public static class TypeBehavior
+    {
+        public static void AssertEqual<T>(T a, T b)
+        {
+            Assert.Equal(a, b);
+            Assert.Equal(b, a);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        public static void AssertNotEqual<T>(T a, T b)
+        {
+            Assert.NotEqual(a, b);
+            Assert.NotEqual(b, a);
+        }
+
+        /// <summary>
+        /// Implements a standard test suite for custom implementations of <c>Equals()</c>
+        /// and <c>GetHashCode()</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The <paramref name="valueFactories"/> parameter is a list of value factories. Each
+        /// factory must produce only instances that are equal to each other, and not equal to
+        /// the instances produced by any of the other factories. The test suite verifies the
+        /// following:
+        /// </para>
+        /// <list type="bullet">
+        /// <item> For any instance <c>a</c> created by any of the factories, <c>a.Equals(a)</c>
+        /// is true, <c>a.Equals(null)</c> is false, and <c>a.equals(x)</c> where <c>x</c> is an
+        /// an instance of a different class is false. </item>
+        /// <item> For any two instances <c>a</c> and <c>b</c> created by the same factory,
+        /// <c>a.Equals(b)</c>, <c>b.Equals(a)</c>, and <c>a.GetHashCode() == b.GetGashCode()</c>
+        /// are all true. </item>
+        /// <item> For any two instances <c>a</c> and <c>b</c> created by different factories,
+        /// <c>a.Equals(b)</c> and <c>b.Equals(a)</c> are false (there is no requirement that
+        /// the hash codes are different). </item>
+        /// </list>
+        /// </remarks>
+        /// <param name="valueFactories">list of factories for distinct values</param>
+        public static void CheckEqualsAndHashCode<T>(params Func<T>[] valueFactories)
+        {
+            for (int i = 0; i < valueFactories.Length; i++)
+            {
+                for (int j = 0; j < valueFactories.Length; j++)
+                {
+                    T value1 = valueFactories[i]();
+                    T value2 = valueFactories[j]();
+                    if (Object.ReferenceEquals(value1, value2))
+                    {
+                        Assert.False(true, "value factory must not return the same instance twice");
+                    }
+                    if (i == j)
+                    {
+                        // instance is equal to itself
+                        Assert.True(value1.Equals(value1), "value was not equal to itself: " + value1);
+
+                        // commutative equality
+                        Assert.True(value1.Equals(value2), "(" + value1 + ").equals(" + value2 + ") was false");
+                        Assert.True(value2.Equals(value1),
+                            "(" + value1 + ").equals(" + value2 + ") was true, but (" +
+                            value2 + ").equals(" + value1 + ") was false");
+
+                        // equal hash code
+                        if (value1.GetHashCode() != value2.GetHashCode())
+                        {
+                            Assert.True(false, "(" + value1 + ").GetHashCode() was " + value1.GetHashCode() + " but ("
+                                + value2 + ").GetHashCode() was " + value2.GetHashCode());
+                        }
+
+                        // unequal to null, unequal to value of wrong class
+                        Assert.False(value1.Equals(null), "value was equal to null: " + value1);
+
+                        Assert.False(value1.Equals(new Object()), "value was equal to Object: " + value1);
+                    }
+                    else
+                    {
+                        // commutative inequality
+                        Assert.False(value1.Equals(value2), "(" + value1 + ").equals(" + value2 + ") was true");
+                        Assert.False(value2.Equals(value1), "(" + value2 + ").equals(" + value1 + ") was true");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a factory that returns the specified instances in order each time it
+        /// is called. After all instances are used, it starts over at the first.
+        /// </summary>
+        /// <remarks>
+        /// This is for use with <see cref="CheckEqualsAndHashCode{T}(Func{T}[])"/>.
+        /// </remarks>
+        /// <typeparam name="T">the value type</typeparam>
+        /// <param name="values">instances of the value</param>
+        /// <returns>a factory function</returns>
+        public static Func<T> ValueFactoryFromInstances<T>(params T[] values)
+        {
+            int counter = 0;
+            return () =>
+            {
+                int i = Interlocked.Increment(ref counter);
+                if (i > values.Length)
+                {
+                    i = 1;
+                }
+                return values[i - 1];
+            };
+        }
+    }
+}

--- a/test/LaunchDarkly.TestHelpers.Tests/AssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/AssertionsTest.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading;
+using Xunit;
+using Xunit.Sdk;
+
+namespace LaunchDarkly.TestHelpers
+{
+    public class AssertionsTest
+    {
+        [Fact]
+        public void AssertEventuallySuccessOnFirstTry()
+        {
+            int calls = 0;
+            Assertions.AssertEventually(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10), () =>
+            {
+                Interlocked.Increment(ref calls);
+                return true;
+            });
+            Assert.Equal(1, calls);
+        }
+
+        [Fact]
+        public void AssertEventuallySuccessBeforeTimeout()
+        {
+            int calls = 0;
+            Assertions.AssertEventually(TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10), () =>
+            {
+                var n = Interlocked.Increment(ref calls);
+                return n > 50;
+            });
+        }
+
+        [Fact]
+        public void AssertEventuallyTimeout()
+        {
+            int calls = 0;
+            Assert.ThrowsAny<XunitException>(() =>
+                Assertions.AssertEventually(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(10), () =>
+                {
+                    var n = Interlocked.Increment(ref calls);
+                    return n > 50;
+                })
+                );
+        }
+    }
+}

--- a/test/LaunchDarkly.TestHelpers.Tests/AssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/AssertionsTest.cs
@@ -42,5 +42,43 @@ namespace LaunchDarkly.TestHelpers
                 })
                 );
         }
+
+#pragma warning disable CS1998
+        [Fact]
+        public async void AssertEventuallyAsyncSuccessOnFirstTry()
+        {
+            int calls = 0;
+            await Assertions.AssertEventuallyAsync(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10), async () =>
+            {
+                Interlocked.Increment(ref calls);
+                return true;
+            });
+            Assert.Equal(1, calls);
+        }
+
+        [Fact]
+        public async void AssertEventuallyAsyncSuccessBeforeTimeout()
+        {
+            int calls = 0;
+            await Assertions.AssertEventuallyAsync(TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10), async () =>
+            {
+                var n = Interlocked.Increment(ref calls);
+                return n > 50;
+            });
+        }
+
+        [Fact]
+        public async void AssertEventuallyAsyncTimeout()
+        {
+            int calls = 0;
+            await Assert.ThrowsAnyAsync<XunitException>(async () =>
+                await Assertions.AssertEventuallyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(10), async () =>
+                {
+                    var n = Interlocked.Increment(ref calls);
+                    return n > 50;
+                })
+                );
+        }
+#pragma warning restore CS1998
     }
 }

--- a/test/LaunchDarkly.TestHelpers.Tests/BuilderBehaviorTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/BuilderBehaviorTest.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using Xunit;
+
+namespace LaunchDarkly.TestHelpers
+{
+    public class BuilderBehaviorTest
+    {
+        [Fact]
+        public void BuildTesterPropertySuccess()
+        {
+            var tester = BuilderBehavior.For(() => new MyBuilder(), b => b.Build());
+            DoBuildTesterAssertions(tester);
+        }
+
+        [Fact]
+        public void BuildTesterWithCopyConstructorPropertySuccess()
+        {
+            var tester = BuilderBehavior.For(() => new MyBuilder(), b => b.Build())
+                .WithCopyConstructor(m => new MyBuilder(m));
+            DoBuildTesterAssertions(tester);
+        }
+
+        private void DoBuildTesterAssertions(BuilderBehavior.BuildTester<MyBuilder, MyType> tester)
+        {
+            var aProp = tester.Property(m => m.A, (b, v) => b.A(v));
+            var bProp = tester.Property(m => m.B, (b, v) => b.B(v));
+            DoValidPropertyAssertions(aProp, bProp);
+        }
+
+        private void DoValidPropertyAssertions(BuilderBehavior.IPropertyAssertions<int> aProp,
+            BuilderBehavior.IPropertyAssertions<int> bProp)
+        {
+            aProp.AssertDefault(MyBuilder.DefaultA);
+            bProp.AssertDefault(MyBuilder.DefaultB);
+
+            aProp.AssertCanSet(5);
+            bProp.AssertCanSet(5);
+
+            bProp.AssertSetIsChangedTo(MyBuilder.MinB - 1, MyBuilder.MinB);
+            bProp.AssertSetIsChangedTo(MyBuilder.MaxB + 1, MyBuilder.MaxB);
+        }
+
+        [Fact]
+        public void BuildTesterInternalStateSuccess()
+        {
+            var tester = BuilderBehavior.For(() => new MyBuilder());
+            var aProp = tester.Property(b => b._a, (b, v) => b.A(v));
+            var bProp = tester.Property(b => b._b, (b, v) => b.B(v));
+            DoValidPropertyAssertions(aProp, bProp);
+        }
+
+        [Fact]
+        public void BuildTesterFailure()
+        {
+            var tester = BuilderBehavior.For(() => new BrokenBuilder(), b => b.Build());
+
+            var aProp = tester.Property(m => m.A, (b, v) => b.A(v));
+            var bProp = tester.Property(m => m.B, (b, v) => b.B(v));
+
+            aProp.AssertDefault(BrokenBuilder.DefaultA);
+            Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => bProp.AssertDefault(BrokenBuilder.DefaultB));
+
+            bProp.AssertCanSet(1);
+            Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => bProp.AssertCanSet(BrokenBuilder.BValueThatFails));
+
+            Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => bProp.AssertSetIsChangedTo(
+                BrokenBuilder.MinB - 1, BrokenBuilder.MinB));
+            Assert.ThrowsAny<Xunit.Sdk.XunitException>(() => bProp.AssertSetIsChangedTo(
+                BrokenBuilder.MaxB + 1, BrokenBuilder.MaxB));
+
+            var copyTester = tester.WithCopyConstructor(m => new BrokenBuilder(m));
+
+        }
+
+        internal class MyBuilder
+        {
+            internal const int DefaultA = 2;
+            internal const int DefaultB = 3;
+            internal const int MinB = 0;
+            internal const int MaxB = 10;
+
+            internal int _a, _b;
+
+            public MyBuilder()
+            {
+                _a = DefaultA;
+                _b = DefaultB;
+            }
+
+            public MyBuilder(MyType m)
+            {
+                _a = m.A;
+                _b = m.B;
+            }
+
+            public MyBuilder A(int a)
+            {
+                _a = a;
+                return this;
+            }
+
+            public MyBuilder B(int b)
+            {
+                _b = b < MinB ? MinB : (b > MaxB ? MaxB : b);
+                return this;
+            }
+
+            public MyType Build() => new MyType(_a, _b);
+        }
+
+        internal class MyType
+        {
+            internal int A { get; }
+            internal int B { get; }
+
+            internal MyType(int a, int b)
+            {
+                A = a;
+                B = b;
+            }
+        }
+
+        internal class BrokenBuilder
+        {
+            internal const int DefaultA = 2;
+            internal const int DefaultB = 3;
+            internal const int MinB = 0;
+            internal const int MaxB = 10;
+            internal const int BValueThatFails = 4;
+
+            internal int _a, _b;
+
+            public BrokenBuilder()
+            {
+                _a = DefaultA;
+                _b = DefaultB + 1;
+            }
+
+            public BrokenBuilder(MyType m)
+            {
+                _a = m.A;
+                _b = m.B + 1;
+            }
+
+            public BrokenBuilder A(int a)
+            {
+                _a = a;
+                return this;
+            }
+
+            public BrokenBuilder B(int b)
+            {
+                _b = b == BValueThatFails ? (b + 1) : b;
+                return this;
+            }
+
+            public MyType Build() => new MyType(_a, _b);
+        }
+
+    }
+}

--- a/test/LaunchDarkly.TestHelpers.Tests/EventSinkTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/EventSinkTest.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Threading;
+using Xunit;
+using Xunit.Sdk;
+
+namespace LaunchDarkly.TestHelpers
+{
+    public class EventSinkTest
+    {
+        [Fact]
+        public void ExpectNoValueSuccessWithDefaultTimeout()
+        {
+            var es = new EventSink<string>();
+            es.ExpectNoValue();
+        }
+
+        [Fact]
+        public void ExpectNoValueSuccessWithSpecifiedTimeout()
+        {
+            var es = new EventSink<string>();
+            es.ExpectNoValue(TimeSpan.FromMilliseconds(200));
+        }
+
+        [Fact]
+        public void ExpectNoValueImmediateFailure()
+        {
+            var es = new EventSink<string>();
+            es.Enqueue("a");
+            Assert.ThrowsAny<XunitException>(() => es.ExpectNoValue());
+        }
+
+        [Fact]
+        public void ExpectNoValueFailureWithinTimeout()
+        {
+            var es = new EventSink<string>();
+            new Thread(() =>
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(50));
+                es.Enqueue("a");
+            }).Start();
+            Assert.ThrowsAny<XunitException>(() => es.ExpectNoValue(TimeSpan.FromMilliseconds(200)));
+        }
+
+        [Fact]
+        public void ExpectValueImmediateSuccess()
+        {
+            var es = new EventSink<string>();
+            es.Enqueue("a");
+            es.Enqueue("b");
+            Assert.Equal("a", es.ExpectValue());
+            Assert.Equal("b", es.ExpectValue());
+        }
+
+        [Fact]
+        public void ExpectValueSuccessWithinTimeout()
+        {
+            var es = new EventSink<string>();
+            new Thread(() =>
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(50));
+                es.Enqueue("a");
+            }).Start();
+            Assert.Equal("a", es.ExpectValue(TimeSpan.FromMilliseconds(200)));
+        }
+
+        [Fact]
+        public void ExpectValueTimeout()
+        {
+            var es = new EventSink<string>();
+            new Thread(() =>
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(200));
+                es.Enqueue("a");
+            }).Start();
+            Assert.ThrowsAny<XunitException>(() => es.ExpectValue(TimeSpan.FromMilliseconds(50)));
+        }
+
+        [Fact]
+        public void AddIsEquivalentToEnqueue()
+        {
+            var es = new EventSink<string>();
+            es.Add(this, "a");
+            Assert.Equal("a", es.ExpectValue());
+        }
+
+        [Fact]
+        public void TryTakeValueImmediateSuccess()
+        {
+            var es = new EventSink<string>();
+            es.Enqueue("a");
+            Assert.True(es.TryTakeValue(out var v));
+            Assert.Equal("a", v);
+        }
+
+        [Fact]
+        public void TryTakeValueSuccessWithinTimeout()
+        {
+            var es = new EventSink<string>();
+            new Thread(() =>
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(50));
+                es.Enqueue("a");
+            }).Start();
+            Assert.True(es.TryTakeValue(out var v));
+            Assert.Equal("a", v);
+        }
+    }
+}

--- a/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+++ b/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
@@ -5,7 +5,7 @@
          single framework that we are testing; this allows us to test with older .NET SDK
          versions that would error out if they saw any newer target frameworks listed
          here, even if we weren't running those. -->
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.0;netcoreapp2.1;net452</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.1;net452;net5.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.TestHelpers.Tests</AssemblyName>
     <PackageId>LaunchDarkly.TestHelpers.Tests</PackageId>

--- a/test/LaunchDarkly.TestHelpers.Tests/TypeBehaviorTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/TypeBehaviorTest.cs
@@ -1,0 +1,166 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+using static LaunchDarkly.TestHelpers.TypeBehavior;
+
+namespace LaunchDarkly.TestHelpers
+{
+    public class TypeBehaviorTest
+    {
+        [Fact]
+        public void TestValueFactoryFromInstances()
+        {
+            var f = ValueFactoryFromInstances("a", "b", "c");
+            Assert.Equal("a", f());
+            Assert.Equal("b", f());
+            Assert.Equal("c", f());
+            Assert.Equal("a", f());
+        }
+
+        [Fact]
+        public void CheckEqualsAndHashCodeSuccess()
+        {
+            CheckEqualsAndHashCode(
+                () => new TypeWithValueAndHashCode("a", 1),
+                () => new TypeWithValueAndHashCode("b", 2),
+                () => new TypeWithValueAndHashCode("c", 2) // hash codes deliberately the same as b - that is allowed             
+                );
+        }
+
+        [Fact]
+        public void CheckEqualsAndHashCodeFailureForIncorrectEquality()
+        {
+            Assert.ThrowsAny<XunitException>(() =>
+                CheckEqualsAndHashCode(
+                    () => new TypeThatEqualsEveryObjectAndAlwaysHasSameHashCode(),
+                    () => new TypeThatEqualsEveryObjectAndAlwaysHasSameHashCode()
+                    ));
+        }
+
+        [Fact]
+        public void CheckEqualsAndHashCodeFailureForEqualingNull()
+        {
+            Assert.ThrowsAny<XunitException>(() =>
+                CheckEqualsAndHashCode(
+                    () => new TypeThatEqualsEveryObjectOrNullAndAlwaysHasSameHashCode()
+                    ));
+        }
+
+        [Fact]
+        public void CheckEqualsAndHashCodeFailureForIncorrectInequality()
+        {
+            Assert.ThrowsAny<XunitException>(() =>
+                CheckEqualsAndHashCode(
+                    () => new TypeThatEqualsOnlyItself()
+                    ));
+        }
+
+        [Fact]
+        public void CheckEqualsAndHashCodeFailureForObjectNotEqualingItself()
+        {
+            Assert.ThrowsAny<XunitException>(() =>
+                CheckEqualsAndHashCode(
+                    () => new TypeThatEqualsNothing()
+                    ));
+        }
+
+        [Fact]
+        public void CheckEqualsAndHashCodeFailureForNonTransitiveEquality()
+        {
+            Assert.ThrowsAny<XunitException>(() =>
+                CheckEqualsAndHashCode(
+                    ValueFactoryFromInstances(
+                        new TypeThatEqualsSameOrHigherValue(1),
+                        new TypeThatEqualsSameOrHigherValue(2))
+                    ));
+        }
+
+        [Fact]
+        public void CheckEqualsAndHashCodeFailureForNonTransitiveInequality()
+        {
+            Assert.ThrowsAny<XunitException>(() =>
+                CheckEqualsAndHashCode(
+                    ValueFactoryFromInstances(
+                        new TypeThatEqualsSameOrHigherValue(1),
+                        new TypeThatEqualsSameOrHigherValue(1)),
+                    ValueFactoryFromInstances(
+                        new TypeThatEqualsSameOrHigherValue(2),
+                        new TypeThatEqualsSameOrHigherValue(2))
+                    ));
+        }
+
+        [Fact]
+        public void CheckEqualsAndHashCodeFailureForInconsistentHashCode()
+        {
+            Assert.ThrowsAny<XunitException>(() =>
+                CheckEqualsAndHashCode(
+                    ValueFactoryFromInstances(
+                        new TypeWithValueAndHashCode("a", 1),
+                        new TypeWithValueAndHashCode("a", 2))
+                    ));
+        }
+
+        internal class TypeWithValueAndHashCode
+        {
+            private readonly string _value;
+            private readonly int _hashCode;
+
+            public TypeWithValueAndHashCode(string value, int hashCode)
+            {
+                _value = value;
+                _hashCode = hashCode;
+            }
+
+            public override bool Equals(object other) =>
+                other is TypeWithValueAndHashCode o && o._value == this._value;
+
+            public override int GetHashCode() => _hashCode;
+
+            public override string ToString() => _value + "/" + _hashCode;
+            }
+        }
+
+        internal class TypeThatEqualsEveryObjectAndAlwaysHasSameHashCode
+        {
+            public override bool Equals(object o) => o != null;
+
+            public override int GetHashCode() => 1;
+        }
+
+        internal class TypeThatEqualsEveryObjectOrNullAndAlwaysHasSameHashCode
+        {
+            public override bool Equals(object o) => true;
+
+            public override int GetHashCode() => 1;
+        }
+
+        internal class TypeThatEqualsOnlyItself
+        {
+            public override bool Equals(object o) => this == o;
+
+            public override int GetHashCode() => 1;
+        }
+
+        internal class TypeThatEqualsNothing
+        {
+            public override bool Equals(object o) => false;
+
+            public override int GetHashCode() => 1;
+        }
+
+        internal class TypeThatEqualsSameOrHigherValue
+        {
+            private readonly int _index;
+
+            public TypeThatEqualsSameOrHigherValue(int index)
+            {
+                _index = index;
+            }
+
+            public override bool Equals(object other) =>
+                other is TypeThatEqualsSameOrHigherValue o &&
+                    o._index >= this._index;
+
+            public override int GetHashCode() => _index;
+    }
+}


### PR DESCRIPTION
These are factored out of dotnet-server-sdk and xamarin-server-sdk test code (and cleaned up a bit) so those projects can share them instead of copying. They are basically C# ports of equivalent types that we have in https://github.com/launchdarkly/java-test-helpers.