### PR TITLE
add JSON test helpers

### DIFF
--- a/docs-src/namespaces/LaunchDarkly.TestHelpers.md
+++ b/docs-src/namespaces/LaunchDarkly.TestHelpers.md
@@ -1,3 +1,3 @@
 General-purpose helper types.
 
-This namespace provides generic tools such as <xref:LaunchDarkly.TestHelpers.BuilderBehavior> and <xref:LaunchDarkly.TestHelpers.TypeBehavior>.
+This namespace provides generic tools such as <xref:LaunchDarkly.TestHelpers.BuilderBehavior> and <xref:LaunchDarkly.TestHelpers.TypeBehavior>; JSON comparison assertions with rich output in <xref:LaunchDarkly.TestHelpers.JsonAssertions>; and other general test helpers.

--- a/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
+++ b/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
@@ -191,8 +191,10 @@ namespace LaunchDarkly.TestHelpers
         }
 
         /// <summary>
-        /// Same as <see cref="AssertJsonEqual(string, string)"/> except that it allows any JSON
-        /// objects in the actual data to contain extra properties that are not in the expected data.
+        /// Similar to <see cref="AssertJsonEqual(string, string)"/> except that when comparing JSON
+        /// objects (at any level) it allows the actual data to contain extra properties that are not in
+        /// the expected data, and when comparing JSON arrays (at any level) it only checks whether the
+        /// expected elements appear somewhere in the actual array in any order.
         /// </summary>
         /// <param name="expected">the expected value</param>
         /// <param name="actual">the actual value</param>
@@ -200,8 +202,10 @@ namespace LaunchDarkly.TestHelpers
             AssertJsonIncludes(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
 
         /// <summary>
-        /// Same as <see cref="AssertJsonEqual(JsonTestValue, JsonTestValue)"/> except that it allows any JSON
-        /// objects in the actual data to contain extra properties that are not in the expected data.
+        /// Similar to <see cref="AssertJsonEqual(JsonTestValue, JsonTestValue)"/> except that when comparing JSON
+        /// objects (at any level) it allows the actual data to contain extra properties that are not in
+        /// the expected data, and when comparing JSON arrays (at any level) it only checks whether the
+        /// expected elements appear somewhere in the actual array in any order.
         /// </summary>
         /// <param name="expected">the expected value</param>
         /// <param name="actual">the actual value</param>
@@ -244,13 +248,18 @@ namespace LaunchDarkly.TestHelpers
                 return true;
             }
             if (expected is JArray ea && actual is JArray aa) {
-                if (ea.Count != aa.Count)
+                foreach (var ev in ea)
                 {
-                    return false;
-                }
-                for (int i = 0; i < ea.Count; i++)
-                {
-                    if (!IsJsonSubset(ea[i], aa[i]))
+                    bool found = false;
+                    foreach (var av in aa)
+                    {
+                        if (IsJsonSubset(ev, av))
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found)
                     {
                         return false;
                     }

--- a/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
+++ b/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
@@ -187,7 +187,8 @@ namespace LaunchDarkly.TestHelpers
             {
                 throw new AssertActualExpectedException(expected, actual, "AssertJsonEqual failed");
             }
-            throw new XunitException("AssertJSONEqual failed:\n" + diff + "\nfull JSON was: " + actual);
+            throw new XunitException(string.Format(
+                "AssertJSONEqual failed:{0}{1}{0}full JSON was: {2}", Environment.NewLine, diff, actual));
         }
 
         /// <summary>
@@ -232,7 +233,8 @@ namespace LaunchDarkly.TestHelpers
             {
                 throw new AssertActualExpectedException(expected, actual, "AssertJsonIncludes failed");
             }
-            throw new XunitException("AssertJsonIncludes failed:\n" + diff + "\nfull JSON was: " + actual);
+            throw new XunitException(string.Format(
+                "AssertJsonIncludes failed:{0}{1}{0}full JSON was: {2}", Environment.NewLine, diff, actual));
         }
 
         private static bool IsJsonSubset(JToken expected, JToken actual)
@@ -324,7 +326,7 @@ namespace LaunchDarkly.TestHelpers
                     }
                 }
             }
-            return string.Join("\n", diffs);
+            return string.Join(Environment.NewLine, diffs);
         }
 
         private static string DescribeJsonArrayDifference(JArray expected, JArray actual, string prefix, bool allowExtraProps)
@@ -352,7 +354,7 @@ namespace LaunchDarkly.TestHelpers
                     }
                 }
             }
-            return string.Join("\n", diffs);
+            return string.Join(Environment.NewLine, diffs);
         }
     }
 }

--- a/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
+++ b/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
@@ -144,6 +144,17 @@ namespace LaunchDarkly.TestHelpers
     /// <summary>
     /// Test assertions related to JSON.
     /// </summary>
+    /// <remarks>
+    /// Examples:
+    /// <code>
+    ///     using static LaunchDarkly.TestHelpers.JsonAssertions;
+    ///     using static LaunchDarkly.TestHelpers.JsonTestValue;
+    ///
+    ///     AssertJsonEquals(@"{""a"":1, ""b"":2}", @"{""b"":2, ""a"":1}");
+    ///     AssertJsonIncludes(@"{""a"":1}", @"{""b"":2, ""a"":1}");
+    ///     AssertJsonEquals(JsonFromValue(true), JsonOf(@"{""a"":true}").Property("a"));
+    /// </code>
+    /// </remarks>
     public class JsonAssertions
     {
         /// <summary>

--- a/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
+++ b/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit.Sdk;
+
+namespace LaunchDarkly.TestHelpers
+{
+    /// <summary>
+    /// A simple wrapper for a string that can be parsed as JSON for tests.
+    /// </summary>
+    /// <remarks>
+    /// This type provides strong typing so that it is clear when test matchers apply to JSON
+    /// values versus strings, and hides the implementation details of parsing and serialization
+    /// which are not relevant to the test logic.
+    /// </remarks>
+    /// <seealso cref="JsonAssertions"/>
+    public struct JsonTestValue
+    {
+        internal readonly string Raw;
+        internal readonly JToken Parsed;
+
+        /// <summary>
+        /// True if there is a value (that is, the original string was not a null reference).
+        /// </summary>
+        public bool IsDefined => Parsed != null;
+
+        private JsonTestValue(string raw, JToken parsed)
+        {
+            Raw = raw;
+            Parsed = parsed;
+        }
+
+        /// <summary>
+        /// Creates a <c>JsonTestValue</c> from a string that should contain JSON.
+        /// </summary>
+        /// <remarks>
+        /// This method fails immediately for any string that is not well-formed JSON. However, if
+        /// it is a null reference, it returns an "undefined" instance that will return <c>false</c>
+        /// from <see cref="IsDefined"/>.
+        /// </remarks>
+        /// <param name="raw">the input string</param>
+        /// <returns>a <c>JsonTestValue</c></returns>
+        /// <exception cref="FormatException">for malformed JSON</exception>
+        public static JsonTestValue JsonOf(string raw)
+        {
+            if (raw is null)
+            {
+                return new JsonTestValue(null, null);
+            }
+            try
+            {
+                return new JsonTestValue(raw, JToken.Parse(raw));
+            }
+            catch (Exception e)
+            {
+                throw new FormatException("not valid JSON (" + e + "): " + raw);
+            }
+        }
+
+        internal static JsonTestValue OfParsed(JToken parsed)
+        {
+            return new JsonTestValue(parsed is null ? null : parsed.ToString(Formatting.None), parsed);
+        }
+
+        /// <summary>
+        /// Creates a <c>JsonTestValue</c> by serializing an arbitrary value to JSON.
+        /// </summary>
+        /// <remarks>
+        /// For instance, <c>JsonFromValue(true)</c> is equivalent to <c>JsonOf("true")</c>.
+        /// This only works for types that are supported by Newtonsoft.Json's default
+        /// reflection-based serialization mechanism.
+        /// </remarks>
+        /// <param name="value">an arbitrary value</param>
+        /// <returns>a <c>JsonTestValue</c></returns>
+        public static JsonTestValue JsonFromValue(object value) =>
+            OfParsed(JToken.FromObject(value));
+
+        /// <summary>
+        /// Returns the JSON as a string, or a "no value" message if undefined.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() =>
+            Raw is null ? "<no value>" : Raw;
+
+        /// <summary>
+        /// Compares two values for deep equality.
+        /// </summary>
+        /// <param name="obj">another JSON value</param>
+        /// <returns>true if the values are deeply equal, or are both undefined</returns>
+        public override bool Equals(object obj) =>
+            obj is JsonTestValue other &&
+            ((!other.IsDefined && !this.IsDefined) ||
+             (other.IsDefined && this.IsDefined && JToken.DeepEquals(other.Parsed, this.Parsed)));
+
+        /// <inheritdoc/>
+        public override int GetHashCode() =>
+            IsDefined ? Parsed.GetHashCode() : 0;
+    }
+
+    /// <summary>
+    /// Test assertions related to JSON.
+    /// </summary>
+    public class JsonAssertions
+    {
+        /// <summary>
+        /// Parses two strings as JSON and compares them for deep equality. If they are unequal,
+        /// it tries to describe the difference as specifically as possible by recursing into
+        /// object properties or array elements.
+        /// </summary>
+        /// <param name="expected">the expected value</param>
+        /// <param name="actual">the actual value</param>
+        /// <exception cref="FormatException">for malformed JSON</exception>
+        public static void AssertJsonEqual(string expected, string actual) =>
+            AssertJsonEqual(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
+
+        /// <summary>
+        /// Compares two JSON values for deep equality. If they are unequal, it tries to describe
+        /// the difference as specifically as possible by recursing into object properties or
+        /// array elements.
+        /// </summary>
+        /// <param name="expected">the expected value</param>
+        /// <param name="actual">the actual value</param>
+        public static void AssertJsonEqual(JsonTestValue expected, JsonTestValue actual)
+        {
+            if (!actual.IsDefined)
+            {
+                if (!expected.IsDefined)
+                {
+                    return;
+                }
+                throw new AssertActualExpectedException(expected, actual, "AssertJsonEqual failed");
+            }
+            if (!expected.IsDefined)
+            {
+                throw new AssertActualExpectedException(expected, actual, "AssertJsonEqual failed");
+            }
+            if (actual.Equals(expected))
+            {
+                return;
+            }
+            var diff = DescribeJsonDifference(expected.Parsed, actual.Parsed, "", false);
+            if (diff is null)
+            {
+                throw new AssertActualExpectedException(expected, actual, "AssertJsonEqual failed");
+            }
+            throw new XunitException("AssertJSONEqual failed:\n" + diff + "\nfull JSON was: " + actual);
+        }
+
+        /// <summary>
+        /// Same as <see cref="AssertJsonEqual(string, string)"/> except that it allows any JSON
+        /// objects in the actual data to contain extra properties that are not in the expected data.
+        /// </summary>
+        /// <param name="expected">the expected value</param>
+        /// <param name="actual">the actual value</param>
+        public static void AssertJsonIncludes(string expected, string actual) =>
+            AssertJsonIncludes(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
+
+        /// <summary>
+        /// Same as <see cref="AssertJsonEqual(JsonTestValue, JsonTestValue)"/> except that it allows any JSON
+        /// objects in the actual data to contain extra properties that are not in the expected data.
+        /// </summary>
+        /// <param name="expected">the expected value</param>
+        /// <param name="actual">the actual value</param>
+        public static void AssertJsonIncludes(JsonTestValue expected, JsonTestValue actual)
+        {
+            if (!actual.IsDefined)
+            {
+                if (!expected.IsDefined)
+                {
+                    return;
+                }
+                throw new AssertActualExpectedException(expected, actual, "AssertJsonIncludes failed");
+            }
+            if (!expected.IsDefined)
+            {
+                throw new AssertActualExpectedException(expected, actual, "AssertJsonIncludes failed");
+            }
+            if (IsJsonSubset(expected.Parsed, actual.Parsed))
+            {
+                return;
+            }
+            var diff = DescribeJsonDifference(expected.Parsed, actual.Parsed, "", true);
+            if (diff is null)
+            {
+                throw new AssertActualExpectedException(expected, actual, "AssertJsonIncludes failed");
+            }
+            throw new XunitException("AssertJsonIncludes failed:\n" + diff + "\nfull JSON was: " + actual);
+        }
+
+        private static bool IsJsonSubset(JToken expected, JToken actual)
+        {
+            if (expected is JObject eo && actual is JObject ao) {
+                foreach (var e in eo)
+                {
+                    if (!ao.TryGetValue(e.Key, out var av) || !IsJsonSubset(e.Value, av))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            if (expected is JArray ea && actual is JArray aa) {
+                if (ea.Count != aa.Count)
+                {
+                    return false;
+                }
+                for (int i = 0; i < ea.Count; i++)
+                {
+                    if (!IsJsonSubset(ea[i], aa[i]))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return JToken.DeepEquals(expected, actual);
+        }
+
+        private static string DescribeJsonDifference(JToken expected, JToken actual, string prefix, bool allowExtraProps)
+        {
+            if (actual is JObject ao && expected is JObject eo)
+            {
+                return DescribeJsonObjectDifference(eo, ao, prefix, allowExtraProps);
+            }
+            if (actual is JArray aa && expected is JArray ea)
+            {
+                return DescribeJsonArrayDifference(ea, aa, prefix, allowExtraProps);
+            }
+            return null;
+        }
+
+        private static string DescribeJsonObjectDifference(JObject expected, JObject actual, string prefix, bool allowExtraProps)
+        {
+            var diffs = new List<string>();
+            foreach (var key in expected.Properties().Select(p => p.Name).Union(actual.Properties().Select(p => p.Name)))
+            {
+                var prefixedKey = prefix + (prefix == "" ? "" : ".") + key;
+                string expectedDesc = null, actualDesc = null, detailDiff = null;
+                if (expected.TryGetValue(key, out var expectedValue))
+                {
+                    if (actual.TryGetValue(key, out var actualValue))
+                    {
+                        if (!JToken.DeepEquals(actualValue, expectedValue))
+                        {
+                            expectedDesc = expectedValue.ToString();
+                            actualDesc = actualValue.ToString();
+                            detailDiff = DescribeJsonDifference(expectedValue, actualValue, prefixedKey, allowExtraProps);
+                        }
+                    }
+                    else
+                    {
+                        expectedDesc = expectedValue.ToString();
+                        actualDesc = "<absent>";
+                    }
+                }
+                else if (!allowExtraProps)
+                {
+                    actualDesc = actual[key].ToString();
+                    expectedDesc = "<absent>";
+                }
+                if (expectedDesc != null || actualDesc != null)
+                {
+                    if (detailDiff != null)
+                    {
+                        diffs.Add(detailDiff);
+                    }
+                    else
+                    {
+                        diffs.Add(string.Format(@"at ""{0}"": expected = {1}, actual = {2}", prefixedKey,
+                            expectedDesc, actualDesc));
+                    }
+                }
+            }
+            return string.Join("\n", diffs);
+        }
+
+        private static string DescribeJsonArrayDifference(JArray expected, JArray actual, string prefix, bool allowExtraProps)
+        {
+            if (expected.Count != actual.Count)
+            {
+                return null; // can't provide a detailed diff, just show the whole values
+            }
+            var diffs = new List<string>();
+            for (int i = 0; i < expected.Count; i++)
+            {
+                var prefixedIndex = string.Format("{0}[{1}]", prefix, i);
+                JToken actualValue = actual[i], expectedValue = expected[i];
+                if (!JToken.DeepEquals(actualValue, expectedValue))
+                {
+                    var detailDiff = DescribeJsonDifference(expectedValue, actualValue, prefixedIndex, allowExtraProps);
+                    if (detailDiff != null)
+                    {
+                        diffs.Add(detailDiff);
+                    }
+                    else
+                    {
+                        diffs.Add(string.Format(@"at ""{0}"": expected = {1}, actual = {2}", prefixedIndex,
+                            expectedValue, actualValue));
+                    }
+                }
+            }
+            return string.Join("\n", diffs);
+        }
+    }
+}

--- a/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
+++ b/src/LaunchDarkly.TestHelpers/JsonAssertions.cs
@@ -88,7 +88,7 @@ namespace LaunchDarkly.TestHelpers
         /// </summary>
         /// <param name="name">the property name</param>
         /// <returns>the value, if any</returns>
-        /// <exception cref="InvalidOperationException">if the current value is not an object</exception>
+        /// <exception cref="XunitException">if the current value is not an object</exception>
         public JsonTestValue Property(string name)
         {
             if (Parsed is JObject o)
@@ -103,7 +103,7 @@ namespace LaunchDarkly.TestHelpers
         /// </summary>
         /// <param name="name">the property name</param>
         /// <returns>the value, if any</returns>
-        /// <exception cref="InvalidOperationException">if the current value is not an object
+        /// <exception cref="XunitException">if the current value is not an object
         /// or it has no such property </exception>
         public JsonTestValue RequiredProperty(string name)
         {

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -7,6 +7,10 @@
     <AssemblyName>LaunchDarkly.TestHelpers</AssemblyName>
     <DebugType>portable</DebugType>
     <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
+    <!-- IsPackable normally defaults to true, but we need to specify it here because
+         otherwise having a dependency on xunit makes NuGet assume we're a test project
+         that shouldn't be made into a package. -->
     <LangVersion>7.3</LangVersion>
     <PackageId>LaunchDarkly.TestHelpers</PackageId>
     <Company>LaunchDarkly</Company>

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -26,9 +26,11 @@
 
   <ItemGroup>
     <None Remove="xunit" />
+    <None Remove="Newtonsoft.Json" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.TestHelpers.xml</DocumentationFile>

--- a/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using Xunit;
+
+namespace LaunchDarkly.TestHelpers
+{
+    public class JsonAssertionsTest
+    {
+        [Fact]
+        public void AssertJsonEqualSuccess()
+        {
+            JsonEqualShouldSucceed("null", "null");
+            JsonEqualShouldSucceed("true", "true");
+            JsonEqualShouldSucceed("1", "1");
+            JsonEqualShouldSucceed("\"x\"", "\"x\"");
+            JsonEqualShouldSucceed("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2},\"a\":1}");
+            JsonEqualShouldSucceed("[1,2,[3,4]]", "[1,2,[3,4]]");
+        }
+
+        private static void JsonEqualShouldSucceed(string expected, string actual)
+        {
+            JsonAssertions.AssertJsonEqual(expected, actual);
+            JsonAssertions.AssertJsonEqual(actual, expected);
+            JsonAssertions.AssertJsonEqual(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
+        }
+
+        [Fact]
+        public void JsonEqualFailureWithNoDetailedDiff()
+        {
+            JsonEqualShouldFail("{\"a\":1,\"b\":2}", "{\"a\":1,\"b\":3}",
+                "at \"b\": expected = 2, actual = 3");
+
+            JsonEqualShouldFail("{\"a\":1,\"b\":2}", "{\"a\":1}",
+                "at \"b\": expected = 2, actual = <absent>");
+
+            JsonEqualShouldFail("{\"a\":1}", "{\"a\":1,\"b\":2}",
+                "at \"b\": expected = <absent>, actual = 2");
+
+            JsonEqualShouldFail("{\"a\":1,\"b\":{\"c\":2}}", "{\"a\":1,\"b\":{\"c\":3}}",
+                "at \"b.c\": expected = 2, actual = 3");
+
+            JsonEqualShouldFail("{\"a\":1,\"b\":[2,3]}", "{\"a\":1,\"b\":[3,3]}",
+                "at \"b\\[0\\]\": expected = 2, actual = 3");
+
+            JsonEqualShouldFail("[100,200,300]", "[100,201,300]",
+                "at \"\\[1\\]\": expected = 200, actual = 201");
+
+            JsonEqualShouldFail("[100,[200,210],300]", "[100,[201,210],300]",
+                "at \"\\[1\\]\\[0\\]\": expected = 200, actual = 201");
+
+            JsonEqualShouldFail("[100,{\"a\":1},300]", "[100,{\"a\":2},300]",
+                "at \"\\[1\\].a\": expected = 1, actual = 2");
+        }
+
+        [Fact]
+        public void JsonEqualFailureWithDetailedDiff()
+        {
+            JsonEqualShouldFail("null", null, "no value");
+            JsonEqualShouldFail("null", "{", "not valid JSON");
+            JsonEqualShouldFail("null", "true", "Expected: *null\nActual: *true");
+            JsonEqualShouldFail("false", "true", "Expected: *false\nActual: *true");
+            JsonEqualShouldFail("{\"a\":1}", "3", "Expected: *{\"a\":1}\nActual: *3");
+            JsonEqualShouldFail("[1,2]", "3", "Expected: *\\[1,2\\]\nActual: *3");
+            JsonEqualShouldFail("[1,2]", "[1,2,3]", "Expected: *\\[1,2\\]\nActual: *\\[1,2,3\\]");
+        }
+
+        private static void JsonEqualShouldFail(string expected, string actual, string expectedMessage)
+        {
+            ShouldFailWithMessage(expectedMessage, () => JsonAssertions.AssertJsonEqual(expected, actual));
+            ShouldFailWithMessage(expectedMessage, () => JsonAssertions.AssertJsonEqual(
+                JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual)));
+        }
+
+        [Fact]
+        public void AssertJsonIncludesSuccess()
+        {
+            JsonIncludesShouldSucceed("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1}");
+            JsonIncludesShouldSucceed("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1,\"c\":3}");
+            JsonIncludesShouldSucceed("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2,\"d\":3},\"a\":1}");
+        }
+
+        private static void JsonIncludesShouldSucceed(string expected, string actual)
+        {
+            JsonAssertions.AssertJsonIncludes(expected, actual);
+            JsonAssertions.AssertJsonIncludes(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
+        }
+
+        [Fact]
+        public void AssertJsonIncludesFailure()
+        {
+            JsonIncludesShouldFail("null", null, "no value");
+            JsonIncludesShouldFail("null", "{", "not valid JSON");
+
+            JsonIncludesShouldFail("{\"a\":1}", "{\"a\":0,\"b\":2,\"c\":3}",
+                "at \"a\": expected = 1, actual = 0");
+
+            JsonIncludesShouldFail("{\"a\":1}", "{\"b\":2,\"c\":3}",
+                "at \"a\": expected = 1, actual = <absent>");
+
+            JsonIncludesShouldFail("{\"b\":2,\"a\":1,\"c\":3}", "{\"a\":1,\"b\":2}",
+                "at \"c\": expected = 3, actual = <absent>");
+
+            JsonIncludesShouldFail("{\"b\":{\"c\":2,\"d\":3},\"a\":1}", "{\"a\":1,\"b\":{\"c\":2}}",
+                "at \"b.d\": expected = 3, actual = <absent>");
+        }
+
+        private static void JsonIncludesShouldFail(string expected, string actual, string expectedMessage)
+        {
+            ShouldFailWithMessage(expectedMessage, () => JsonAssertions.AssertJsonIncludes(expected, actual));
+            ShouldFailWithMessage(expectedMessage, () => JsonAssertions.AssertJsonIncludes(
+                JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual)));
+        }
+
+        private static void ShouldFailWithMessage(string expectedMessage, Action action)
+        {
+            var ex = Assert.ThrowsAny<Exception>(action);
+            Assert.Matches(expectedMessage, ex.Message);
+        }
+    }
+
+    public class JsonTestValueTest
+    {
+        [Fact]
+        public void ParseUndefined()
+        {
+            var v = JsonTestValue.JsonOf(null);
+            Assert.False(v.IsDefined);
+            Assert.Equal("<no value>", v.ToString());
+        }
+
+        [Fact]
+        public void ParseMalformed()
+        {
+            Assert.ThrowsAny<FormatException>(() => JsonTestValue.JsonOf("{no"));
+        }
+
+        [Fact]
+        public void ParseSuccess()
+        {
+            var v = JsonTestValue.JsonOf("123");
+            Assert.True(v.IsDefined);
+            Assert.Equal("123", v.ToString());
+        }
+
+        [Fact]
+        public void FromValue()
+        {
+            Assert.Equal(JsonTestValue.JsonOf("123"), JsonTestValue.JsonFromValue(123));
+            Assert.Equal(JsonTestValue.JsonOf("true"), JsonTestValue.JsonFromValue(true));
+        }
+
+        [Fact]
+        public void DeepEquality()
+        {
+            Assert.Equal(JsonTestValue.JsonOf(@"{""a"":[1,2],""b"":true}"),
+                JsonTestValue.JsonOf(@"{""b"":true,""a"":[1,2]}"));
+
+            Assert.NotEqual(JsonTestValue.JsonOf(@"{""a"":[1,2],""b"":true}"),
+                JsonTestValue.JsonOf(@"{""b"":true,""a"":[1,3]}"));
+        }
+    }
+}

--- a/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
@@ -57,11 +57,11 @@ namespace LaunchDarkly.TestHelpers
         {
             JsonEqualShouldFail("null", null, "no value");
             JsonEqualShouldFail("null", "{", "not valid JSON");
-            JsonEqualShouldFail("null", "true", "Expected: *null\nActual: *true");
-            JsonEqualShouldFail("false", "true", "Expected: *false\nActual: *true");
-            JsonEqualShouldFail("{\"a\":1}", "3", "Expected: *{\"a\":1}\nActual: *3");
-            JsonEqualShouldFail("[1,2]", "3", "Expected: *\\[1,2\\]\nActual: *3");
-            JsonEqualShouldFail("[1,2]", "[1,2,3]", "Expected: *\\[1,2\\]\nActual: *\\[1,2,3\\]");
+            JsonEqualShouldFail("null", "true", ExpectedAndActualMessage("null", "true"));
+            JsonEqualShouldFail("false", "true", ExpectedAndActualMessage("false", "true"));
+            JsonEqualShouldFail("{\"a\":1}", "3", ExpectedAndActualMessage("{\"a\":1}", "3"));
+            JsonEqualShouldFail("[1,2]", "3", ExpectedAndActualMessage("\\[1,2\\]", "3"));
+            JsonEqualShouldFail("[1,2]", "[1,2,3]", ExpectedAndActualMessage("\\[1,2\\]", "\\[1,2,3\\]"));
         }
 
         private static void JsonEqualShouldFail(string expected, string actual, string expectedMessage)
@@ -125,6 +125,9 @@ namespace LaunchDarkly.TestHelpers
             var ex = Assert.ThrowsAny<Exception>(action);
             Assert.Matches(expectedMessage, ex.Message);
         }
+
+        private static string ExpectedAndActualMessage(string expected, string actual) =>
+            "Expected: *" + expected + Environment.NewLine + "Actual: *" + actual;
     }
 
     public class JsonTestValueTest

--- a/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
@@ -77,6 +77,11 @@ namespace LaunchDarkly.TestHelpers
             JsonIncludesShouldSucceed("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1}");
             JsonIncludesShouldSucceed("{\"a\":1,\"b\":2}", "{\"b\":2,\"a\":1,\"c\":3}");
             JsonIncludesShouldSucceed("{\"a\":1,\"b\":{\"c\":2}}", "{\"b\":{\"c\":2,\"d\":3},\"a\":1}");
+
+            JsonIncludesShouldSucceed("[1,2,3]", "[1,2,3]");
+            JsonIncludesShouldSucceed("[3,1]", "[1,2,3]");
+            JsonIncludesShouldSucceed("[1,[4],5]", "[1,[2,3,4],5]");
+            JsonIncludesShouldSucceed("[1,{\"a\":2}]", "[{\"a\":2,\"b\":3},1]");
         }
 
         private static void JsonIncludesShouldSucceed(string expected, string actual)
@@ -102,6 +107,10 @@ namespace LaunchDarkly.TestHelpers
 
             JsonIncludesShouldFail("{\"b\":{\"c\":2,\"d\":3},\"a\":1}", "{\"a\":1,\"b\":{\"c\":2}}",
                 "at \"b.d\": expected = 3, actual = <absent>");
+
+            JsonIncludesShouldFail("[3,1]", "[2,3]", "failed"); // diff isn't very helpful for these cases
+            JsonIncludesShouldFail("[1,[4],5]", "[1,[2,3],5]", "failed");
+            JsonIncludesShouldFail("[1,{\"a\":2}]", "[{\"b\":3},1]", "failed");
         }
 
         private static void JsonIncludesShouldFail(string expected, string actual, string expectedMessage)

--- a/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Xunit;
+using Xunit.Sdk;
 
 namespace LaunchDarkly.TestHelpers
 {
@@ -125,6 +126,7 @@ namespace LaunchDarkly.TestHelpers
             var v = JsonTestValue.JsonOf(null);
             Assert.False(v.IsDefined);
             Assert.Equal("<no value>", v.ToString());
+            Assert.Equal(JsonTestValue.NoValue, v);
         }
 
         [Fact]
@@ -156,6 +158,26 @@ namespace LaunchDarkly.TestHelpers
 
             Assert.NotEqual(JsonTestValue.JsonOf(@"{""a"":[1,2],""b"":true}"),
                 JsonTestValue.JsonOf(@"{""b"":true,""a"":[1,3]}"));
+        }
+
+        [Fact]
+        public void OptionalProperty()
+        {
+            Assert.Equal(JsonTestValue.JsonOf("true"), JsonTestValue.JsonOf(@"{""a"":true}").Property("a"));
+            Assert.Equal(JsonTestValue.JsonOf(null), JsonTestValue.JsonOf(@"{""a"":true}").Property("b"));
+
+            Assert.ThrowsAny<XunitException>(() => JsonTestValue.JsonOf("true").Property("a"));
+            Assert.ThrowsAny<XunitException>(() => JsonTestValue.JsonOf(null).Property("a"));
+        }
+
+        [Fact]
+        public void RequiredProperty()
+        {
+            Assert.Equal(JsonTestValue.JsonOf("true"), JsonTestValue.JsonOf(@"{""a"":true}").RequiredProperty("a"));
+
+            Assert.ThrowsAny<XunitException>(() => JsonTestValue.JsonOf(@"{""a"":true}").RequiredProperty("b"));
+            Assert.ThrowsAny<XunitException>(() => JsonTestValue.JsonOf("true").RequiredProperty("a"));
+            Assert.ThrowsAny<XunitException>(() => JsonTestValue.JsonOf(null).RequiredProperty("a"));
         }
     }
 }


### PR DESCRIPTION
This is a pretty straightforward port of the [equivalent code](https://github.com/launchdarkly/java-test-helpers/blob/master/src/main/java/com/launchdarkly/testhelpers/JsonAssertions.java) from `java-test-helpers`.

The background is that our SDK unit tests do a lot of comparisons of JSON output, which can't be a plain string compare, so we always have to use some library type (such as our own `LdValue`) to parse the JSON and do a deep-equality comparison... but then if the comparison fails, the test framework's default behavior means you get a dump of the entire content, which could make it hard to find the specific problem. So, the most basic thing these helpers give us is an equality assertion that prints a slightly better diff on failure.

We can also do some other simple kinds of comparisons using the abstraction here to hide the implementation details of whatever JSON library is being used. The Java version used Gson; this version uses Newtonsoft.Json. I know we've gone to some lengths to remove Newtonsoft.Json from our code, but this is only for _test_ code and we do need something portable (other than our own implementation— I don't like using `LdValue` for this purpose because that creates a dependency on a particular version of `LaunchDarkly.CommonSdk`, and anyway `LdValue` is designed for simple use cases in the SDKs rather than for test assertions).

Also, we're using Xunit which doesn't have an equivalent to Hamcrest test matchers, so this only includes the basic methods rather than the richer composable property tests that are in the Java version. To partly make up for that, I made the behavior of `AssertJsonIncludes` more sophisticated for arrays (since one thing we often used combinators for in the Java SDK tests was "this JSON array should contain the following elements in any order").