### PR TITLE
make MessageHandlerFromHandler more portable + add SequentialWithLastRepeating

### DIFF
--- a/src/LaunchDarkly.TestHelpers/HttpTest/Handlers_Combinators.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/Handlers_Combinators.cs
@@ -57,8 +57,23 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         /// </remarks>
         /// <param name="handlers">a list of handlers</param>
         /// <returns>a <see cref="Handler"/></returns>
+        /// <seealso cref="SequentialWithLastRepeating(Handler[])"/>
         public static Handler Sequential(params Handler[] handlers) =>
-            new SequentialHandler(handlers).Handler;
+            new SequentialHandler(false, handlers).Handler;
+
+        /// <summary>
+        /// Creates a <see cref="Handler"/> that delegates to each of the specified handlers in sequence
+        /// as each request is received.
+        /// </summary>
+        /// <remarks>
+        /// Any requests that happen after the last handler in the list has been used will continue to
+        /// use the last handler.
+        /// </remarks>
+        /// <param name="handlers">a list of handlers</param>
+        /// <returns>a <see cref="Handler"/></returns>
+        /// <seealso cref="Sequential(Handler[])"/>
+        public static Handler SequentialWithLastRepeating(params Handler[] handlers) =>
+            new SequentialHandler(true, handlers).Handler;
 
         /// <summary>
         /// Creates a <see cref="HandlerSwitcher"/> for changing handler behavior dynamically.

--- a/src/LaunchDarkly.TestHelpers/HttpTest/MessageHandlerFromHandler.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/MessageHandlerFromHandler.cs
@@ -105,6 +105,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 if (_pipe is null)
                 {
                     _pipe = new SimplePipe();
+                    CancellationToken.Register(_pipe.Close);
                     _response.Content = new StreamContent(_pipe);
                     _response.Content.Headers.ContentEncoding.Add("chunked");
                     if (_deferredContentType != null)

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SequentialHandlerTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SequentialHandlerTest.cs
@@ -8,7 +8,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
     public class SequentialHandlerTest
     {
         [Fact]
-        public async Task HandlersAreCalledInSequence()
+        public async Task HandlersAreCalledInSequenceAndLastIsNotRepeated()
         {
             var handler = Handlers.Sequential(Handlers.Status(200), Handlers.Status(201));
 
@@ -22,6 +22,24 @@ namespace LaunchDarkly.TestHelpers.HttpTest
 
                 var resp3 = await client.GetAsync(server.Uri);
                 Assert.Equal(500, (int)resp3.StatusCode);
+            });
+        }
+
+        [Fact]
+        public async Task HandlersAreCalledInSequenceAndLastIsRepeated()
+        {
+            var handler = Handlers.SequentialWithLastRepeating(Handlers.Status(200), Handlers.Status(201));
+
+            await WithServerAndClient(handler, async (server, client) =>
+            {
+                var resp1 = await client.GetAsync(server.Uri);
+                Assert.Equal(200, (int)resp1.StatusCode);
+
+                var resp2 = await client.GetAsync(server.Uri);
+                Assert.Equal(201, (int)resp2.StatusCode);
+
+                var resp3 = await client.GetAsync(server.Uri);
+                Assert.Equal(201, (int)resp3.StatusCode);
             });
         }
     }


### PR DESCRIPTION
Two improvements to the HTTP helpers:

1. `MessageHandlerFromHandler`, which is an adapter between the "handlers for a fake server" kind of handler and the "handlers for an HttpClient" kind, turned out not to work right in Xamarin because it relied on I/O pipe classes that apparently aren't implemented in Xamarin. That made it hard to do certain kinds of streaming tests. I wrote a more portable implementation of the basic "pipe one stream into another" behavior.

2. I added the combinator `Handlers.SequentialWithLastRepeating`, which is the same as `Sequential` in that you provide a list of canned responses, but the last one gets reused for any further requests that happen. That's useful in tests of SDK polling mode, when we only care about the first couple of polls but we don't want to cause errors if more polls happen. I already had to implement this in the `dotnet-server-sdk` tests so we may as well reuse it.