### PR TITLE
add features for mini HTTP services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,23 +10,33 @@ workflows:
       - test-netcore:
           name: .NET Core 2.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
+          build-target-framework: netstandard2.0
           test-target-framework: netcoreapp2.1
       - test-netcore:
           name: .NET Core 3.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+          build-target-framework: netcoreapp3.1
           test-target-framework: netcoreapp3.1
       - test-netcore:
           name: .NET 5.0
           docker-image: mcr.microsoft.com/dotnet/sdk:5.0-focal
+          build-target-framework: netstandard2.0
           test-target-framework: net5.0
       - test-windows-netframework:
           name: .NET Framework 4.5.2
+          build-target-framework: net452
           test-target-framework: net452
+      - test-windows-netframework:
+          name: .NET Framework 4.5.2
+          build-target-framework: net461
+          test-target-framework: net461
 
 jobs:
   test-netcore:
     parameters:
       docker-image:
+        type: string
+      build-target-framework:
         type: string
       test-target-framework:
         type: string
@@ -34,22 +44,26 @@ jobs:
       - image: <<parameters.docker-image>>
     environment:
       ASPNETCORE_SUPPRESSSTATUSMESSAGES: true
+      BUILDFRAMEWORKS: <<parameters.build-target-framework>>
       TESTFRAMEWORK: <<parameters.test-target-framework>>
     steps:
       - checkout
-      - run: dotnet build src/LaunchDarkly.TestHelpers -f netstandard2.0
+      - run: dotnet build src/LaunchDarkly.TestHelpers
       - run: dotnet test test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
 
   test-windows-netframework:
     parameters:
+      build-target-framework:
+        type: string
       test-target-framework:
         type: string
     executor:
       name: win/vs2019
       shell: powershell.exe
     environment:
+      BUILDFRAMEWORKS: <<parameters.build-target-framework>>
       TESTFRAMEWORK: <<parameters.test-target-framework>>
     steps:
       - checkout
-      - run: dotnet build src/LaunchDarkly.TestHelpers -f net452
+      - run: dotnet build src/LaunchDarkly.TestHelpers
       - run: dotnet test test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ workflows:
           build-target-framework: net452
           test-target-framework: net452
       - test-windows-netframework:
-          name: .NET Framework 4.5.2
+          name: .NET Framework 4.6.1
           build-target-framework: net461
           test-target-framework: net461
 

--- a/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
@@ -157,7 +157,6 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                         }
                         catch(Exception e)
                         {
-                            System.Console.WriteLine("******* " + e);
                             // an exception almost certainly means the listener has been shut down
                             break;
                         }

--- a/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
@@ -19,6 +19,10 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         /// <summary>
         /// Returns the <see cref="RequestRecorder"/> that captures all requests to this server.
         /// </summary>
+        /// <remarks>
+        /// This is enabled by default. To turn off capturing of requests, set the
+        /// <see cref="RequestRecorder.Enabled"/> property of this object to false.
+        /// </remarks>
         public RequestRecorder Recorder => _recorder;
 
         private readonly HttpListener _listener;
@@ -53,7 +57,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         }
 
         /// <summary>
-        /// Starts a new test server.
+        /// Starts a new test server on an arbitrary available port.
         /// </summary>
         /// <remarks>
         /// Make sure to close this when done, by calling <c>Dispose</c> or with a <c>using</c>
@@ -64,27 +68,47 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         /// to change the behavior of the handler during the lifetime of the server, use
         /// <see cref="Handlers.Switchable(out HandlerSwitcher)"/>.</param>
         /// <returns>the started server instance</returns>
-        public static HttpServer Start(Handler handler)
+        public static HttpServer Start(Handler handler) =>
+            StartInternal(null, handler);
+
+        /// <summary>
+        /// Starts a new test server on a specific port.
+        /// </summary>
+        /// <remarks>
+        /// Make sure to close this when done, by calling <c>Dispose</c> or with a <c>using</c>
+        /// statement.
+        /// </remarks>
+        /// <param name="port">The port to listen on.</param>
+        /// <param name="handler">A function that will handle all requests to this server. Use
+        /// the factory methods in <see cref="Handlers"/> for standard handlers. If you will need
+        /// to change the behavior of the handler during the lifetime of the server, use
+        /// <see cref="Handlers.Switchable(out HandlerSwitcher)"/>.</param>
+        /// <returns>the started server instance</returns>
+        public static HttpServer Start(int port, Handler handler) =>
+            StartInternal(port, handler);
+
+        private static HttpServer StartInternal(int? port, Handler handler)
         {
             // HttpListener doesn't seem to have a per-request cancellation token, so we'll create
             // one for the entire server to ensure that handlers will exit if it's being stopped.
             var canceller = new CancellationTokenSource();
 
             var rootHandler = Handlers.Record(out var recorder).Then(handler);
-            var listener = StartWebServerOnAvailablePort(canceller.Token, rootHandler, out var uri);
+            var listener = StartWebServerOnAvailablePort(canceller.Token, port, rootHandler, out var uri);
 
             EnsureServerIsListening(uri);
-            
+
             return new HttpServer(listener, canceller, recorder, uri);
         }
 
         private static HttpListener StartWebServerOnAvailablePort(
             CancellationToken cancellationToken,
+            int? specificPort,
             Handler rootHandler,
             out Uri serverUriOut
             )
         {
-            var port = FindNextPort();
+            var port = specificPort ?? FindNextPort();
 
             while (true)
             {
@@ -96,7 +120,12 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 }
                 catch (HttpListenerException)
                 {
-                    // Ssometimes the logic used in FindNextPort will return a port that's not really available after
+                    if (specificPort.HasValue)
+                    {
+                        // If a specific port was requested, then we should fail if we can't get that one.
+                        throw;
+                    }
+                    // Sometimes the logic used in FindNextPort will return a port that's not really available after
                     // all-- possibly due to a delay in cleaning up the temporary listener that FindNextPort creates.
                     // There's not a great solution for this as far as I know, we just have to try another port.
                     port++;
@@ -118,11 +147,11 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                             });
 #pragma warning restore CS4014
 
-                    }
+                        }
                         catch
                         {
-                        // an exception almost certainly means the listener has been shut down
-                        break;
+                            // an exception almost certainly means the listener has been shut down
+                            break;
                         }
                     }
                 });

--- a/src/LaunchDarkly.TestHelpers/HttpTest/IRequestContext.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/IRequestContext.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace LaunchDarkly.TestHelpers.HttpTest
@@ -75,5 +74,29 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         /// <param name="data">the data</param>
         /// <returns>an asynchronous task</returns>
         Task WriteFullResponseAsync(string contentType, byte[] data);
+
+        /// <summary>
+        /// Returns a path parameter, if any path parameters were captured.
+        /// </summary>
+        /// <remarks>
+        /// By default, this will always return null. It is non-null only if you used
+        /// <see cref="SimpleRouter"/> and matched a regex pattern that was added with
+        /// <see cref="SimpleRouter.AddRegex(System.Net.Http.HttpMethod, string, Handler)"/>,
+        /// and the pattern contained capture groups. For instance, if the pattern was
+        /// <code>/a/([^/]*)/c/(.*)</code> and the request path was <code>/a/b/c/d/e</code>,
+        /// <code>GetPathParam(0)</code> would return <code>"b"</code> and
+        /// <code>GetPathParam(1)</code> would return <code>"d/e"</code>.
+        /// </remarks>
+        /// <param name="index">a zero-based index</param>
+        /// <returns>the path parameter string; null if there were no path parameters, or if
+        /// the index is out of range</returns>
+        string GetPathParam(int index);
+
+        /// <summary>
+        /// Returns a copy of this context with path parameter information added.
+        /// </summary>
+        /// <param name="pathParams">an array of positional parameters</param>
+        /// <returns>a transformed context</returns>
+        IRequestContext WithPathParams(string[] pathParams);
     }
 }

--- a/src/LaunchDarkly.TestHelpers/HttpTest/MessageHandlerFromHandler.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/MessageHandlerFromHandler.cs
@@ -66,7 +66,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
 
             private readonly HttpResponseMessage _response = new HttpResponseMessage();
             private SimplePipe _pipe;
-            
+
             private string _deferredContentType;
 
             internal void MakeResponseAvailable()

--- a/src/LaunchDarkly.TestHelpers/HttpTest/MessageHandlerFromHandler.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/MessageHandlerFromHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Net;
@@ -61,10 +62,11 @@ namespace LaunchDarkly.TestHelpers.HttpTest
             public RequestInfo RequestInfo { get; set; }
             public CancellationToken CancellationToken { get; set; }
             public TaskCompletionSource<HttpResponseMessage> Ready = new TaskCompletionSource<HttpResponseMessage>();
+            public string[] PathParams { get; set; }
 
             private readonly HttpResponseMessage _response = new HttpResponseMessage();
             private SimplePipe _pipe;
-
+            
             private string _deferredContentType;
 
             internal void MakeResponseAvailable()
@@ -134,6 +136,18 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 MakeResponseAvailable();
                 await Task.Yield();
             }
+
+            public string GetPathParam(int index) =>
+                (PathParams != null && index >= 0 && index < PathParams.Length) ?
+                PathParams[index] : null;
+
+            public IRequestContext WithPathParams(string[] pathParams) =>
+                new FakeRequestContext
+                {
+                    RequestInfo = this.RequestInfo,
+                    CancellationToken = this.CancellationToken,
+                    PathParams = pathParams
+                };
         }
 
         // HttpMessageHandler has to provide the response body as a stream, which we might be

--- a/src/LaunchDarkly.TestHelpers/HttpTest/RequestRecorder.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/RequestRecorder.cs
@@ -20,6 +20,8 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
 
         private readonly BlockingCollection<RequestInfo> _requests = new BlockingCollection<RequestInfo>();
+        private readonly object _lock = new object();
+        private volatile bool _enabled = true;
 
         /// <summary>
         /// Returns the stable <see cref="Handler"/> that is the external entry point to this
@@ -32,6 +34,27 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         /// The number of requests currently in the queue.
         /// </summary>
         public int Count => _requests.Count;
+
+        /// <summary>
+        /// Set this property to false to turn off recording of requests. It is true by default.
+        /// </summary>
+        public bool Enabled
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _enabled;
+                }
+            }
+            set
+            {
+                lock (_lock)
+                {
+                    _enabled = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Consumes and returns the first request in the queue, blocking until one is available.
@@ -73,7 +96,10 @@ namespace LaunchDarkly.TestHelpers.HttpTest
 #pragma warning disable CS1998 // async method with no awaits
         private async Task DoRequestAsync(IRequestContext ctx)
         {
-            _requests.Add(ctx.RequestInfo);
+            if (Enabled)
+            {
+                _requests.Add(ctx.RequestInfo);
+            }
         }
 #pragma warning restore CS1998
 

--- a/src/LaunchDarkly.TestHelpers/HttpTest/RequestRecorder.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/RequestRecorder.cs
@@ -20,7 +20,6 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
 
         private readonly BlockingCollection<RequestInfo> _requests = new BlockingCollection<RequestInfo>();
-        private readonly object _lock = new object();
         private volatile bool _enabled = true;
 
         /// <summary>
@@ -42,17 +41,11 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         {
             get
             {
-                lock (_lock)
-                {
-                    return _enabled;
-                }
+                return _enabled;
             }
             set
             {
-                lock (_lock)
-                {
-                    _enabled = value;
-                }
+                _enabled = value;
             }
         }
 

--- a/src/LaunchDarkly.TestHelpers/HttpTest/SimpleJsonService.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/SimpleJsonService.cs
@@ -1,0 +1,243 @@
+﻿#if !NET452
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace LaunchDarkly.TestHelpers.HttpTest
+{   
+    /// <summary>
+    /// A minimal framework for a JSON-based REST service.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class builds on <see cref="Handlers"/> and <see cref="SimpleRouter"/> to provide a
+    /// simplified structure for implementing a basic REST service that can use JSON-serializable
+    /// types for request and response bodies. For very basic services that are used in a test
+    /// scenario, this is much lighter-weight and more portable than using ASP.NET Core or ASP.NET.
+    /// </para>
+    /// <para>
+    /// The basic pattern is to call the <c>Route</c> methods to map any number of endpoint
+    /// handlers. Each handler method takes an <see cref="IRequestContext"/> as the first
+    /// parameter, and can optionally take a value of some JSON-deserializable type as a second
+    /// parameter, which will be automatically parsed from the request body. Its return value is
+    /// either a <see cref="SimpleResponse"/> if there is no response body, or a
+    /// <see cref="SimpleResponse{T}"/> containing a value that will be serialized to JSON as a
+    /// response body.
+    /// </para>
+    /// <para>
+    /// For simple path parameters, you may inclue a regex containing capture groups in the path,
+    /// and then call <see cref="IRequestContext.GetPathParam(int)"/> to get the value. Any path
+    /// containing parentheses is assumed to be a regex, otherwise it is taken as a literal.
+    /// </para>
+    /// <para>
+    /// Because this class uses <code>System.Text.Json</code>, it is not available in .NET
+    /// Framework 4.5.x.
+    /// </para>
+    /// </remarks>
+    public sealed class SimpleJsonService
+    {
+        /// <summary>
+        /// Returns the stable <see cref="Handler"/> that is the external entry point to this
+        /// delegator. This is used implicitly if you use a <c>SimpleJsonService</c> anywhere that
+        /// a <see cref="Handler"/> is expected.
+        /// </summary>
+        public Handler Handler => _handler;
+
+#pragma warning disable CS1591 // no doc comment for this implicit conversion
+        public static implicit operator Handler(SimpleJsonService me) => me.Handler;
+#pragma warning restore CS1591
+
+        private readonly Handler _handler;
+        private readonly SimpleRouter _router;
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        public SimpleJsonService()
+        {
+            _handler = Handlers.Router(out _router);
+        }
+
+        /// <summary>
+        /// Adds an asynchronous endpoint handler with no request body parameters and no response body.
+        /// </summary>
+        /// <param name="method">the HTTP method</param>
+        /// <param name="path">the endpoint path</param>
+        /// <param name="asyncHandler">the handler</param>
+        public void Route(
+            HttpMethod method,
+            string path,
+            Func<IRequestContext, Task<SimpleResponse>> asyncHandler
+        ) =>
+            AddPathInternal(method, path, Wrap(asyncHandler));
+
+        /// <summary>
+        /// Adds an asynchronous endpoint handler with a JSON request body parameter and no response body.
+        /// </summary>
+        /// <param name="method">the HTTP method</param>
+        /// <param name="path">the endpoint path</param>
+        /// <param name="asyncHandler">the handler</param>
+        public void Route<TInput>(
+            HttpMethod method,
+            string path,
+            Func<IRequestContext, TInput, Task<SimpleResponse>> asyncHandler
+        ) =>
+            AddPathInternal(method, path, Wrap(asyncHandler));
+
+        /// <summary>
+        /// Adds an asynchronous endpoint handler with no request body parameters and a JSON response.
+        /// </summary>
+        /// <param name="method">the HTTP method</param>
+        /// <param name="path">the endpoint path</param>
+        /// <param name="asyncHandler">the handler</param>
+        public void Route<TOutput>(
+            HttpMethod method,
+            string path,
+            Func<IRequestContext, Task<SimpleResponse<TOutput>>> asyncHandler
+        ) =>
+            AddPathInternal(method, path, Wrap(asyncHandler));
+
+        /// <summary>
+        /// Adds an asynchronous endpoint handler with a JSON request body parameter and a JSON response.
+        /// </summary>
+        /// <param name="method">the HTTP method</param>
+        /// <param name="path">the endpoint path</param>
+        /// <param name="asyncHandler">the handler</param>
+        public void Route<TInput, TOutput>(
+            HttpMethod method,
+            string path,
+            Func<IRequestContext, TInput, Task<SimpleResponse<TOutput>>> asyncHandler
+        ) =>
+            AddPathInternal(method, path, Wrap(asyncHandler));
+
+        /// <summary>
+        /// Adds a synchronous endpoint handler with no request body parameters and no response body.
+        /// </summary>
+        /// <param name="method">the HTTP method</param>
+        /// <param name="path">the endpoint path</param>
+        /// <param name="syncHandler">the handler</param>
+        public void Route(
+            HttpMethod method,
+            string path,
+            Func<IRequestContext, SimpleResponse> syncHandler
+        ) =>
+            AddPathInternal(method, path, Wrap(context => Task.FromResult(syncHandler(context))));
+
+        /// <summary>
+        /// Adds a synchronous endpoint handler with no request body parameters and a JSON response.
+        /// </summary>
+        /// <param name="method">the HTTP method</param>
+        /// <param name="path">the endpoint path</param>
+        /// <param name="syncHandler">the handler</param>
+        public void Route<TInput>(
+            HttpMethod method,
+            string path,
+            Func<IRequestContext, TInput, SimpleResponse> syncHandler
+        ) =>
+            AddPathInternal(method, path, Wrap(
+                (IRequestContext context, TInput input) => Task.FromResult(syncHandler(context, input))));
+
+        /// <summary>
+        /// Adds a synchronous endpoint handler with no request body parameters and a JSON response.
+        /// </summary>
+        /// <param name="method">the HTTP method</param>
+        /// <param name="path">the endpoint path</param>
+        /// <param name="syncHandler">the handler</param>
+        public void Route<TOutput>(
+        HttpMethod method,
+            string path,
+            Func<IRequestContext, SimpleResponse<TOutput>> syncHandler
+        ) =>
+            AddPathInternal(method, path, Wrap(context => Task.FromResult(syncHandler(context))));
+
+        /// <summary>
+        /// Adds an asynchronous endpoint handler with a JSON request body parameter and a JSON response.
+        /// </summary>
+        /// <param name="method">the HTTP method</param>
+        /// <param name="path">the endpoint path</param>
+        /// <param name="syncHandler">the handler</param>
+        public void Route<TInput, TOutput>(
+            HttpMethod method,
+            string path,
+            Func<IRequestContext, TInput, SimpleResponse<TOutput>> syncHandler
+        ) =>
+            AddPathInternal(method, path, Wrap(
+                (IRequestContext context, TInput input) => Task.FromResult(syncHandler(context, input))));
+
+        private void AddPathInternal(HttpMethod method, string path, Handler handler)
+        {
+            if (path.Contains("("))
+            {
+                _router.AddRegex(method, path, handler);
+            }
+            else
+            {
+                _router.AddPath(method, path, handler);
+            }
+        }
+
+        private Handler Wrap(Func<IRequestContext, Task<SimpleResponse>> handler) =>
+            async context =>
+            {
+                var result = await handler(context);
+                await Handlers.Status(result.Status)(context);
+                foreach (var kv in result.Headers)
+                {
+                    foreach (var v in kv.Value)
+                    {
+                        await Handlers.Header(kv.Key, v)(context);
+                    }
+                }
+            };
+
+        private Handler Wrap<TInput>(Func<IRequestContext, TInput, Task<SimpleResponse>> handler) =>
+            Wrap(async context =>
+            {
+                if (!ParseInput<TInput>(context, out var input))
+                {
+                    return SimpleResponse.Of(400);
+                }
+                return await handler(context, input);
+            });
+
+        private Handler Wrap<TOutput>(Func<IRequestContext, Task<SimpleResponse<TOutput>>> handler) =>
+            Wrap(async context =>
+            {
+                var result = await handler(context);
+                if (typeof(TOutput).IsValueType || !result.Body.Equals(default(TOutput)))
+                {
+                    await Handlers.BodyJson(JsonSerializer.Serialize(result.Body))(context);
+                }
+                return result.Base;
+            });
+
+        private Handler Wrap<TInput, TOutput>(Func<IRequestContext, TInput, Task<SimpleResponse<TOutput>>> handler) =>
+            Wrap(async context =>
+            {
+                if (!ParseInput<TInput>(context, out var input))
+                {
+                    return SimpleResponse.Of(400);
+                }
+                var result = await handler(context, input);
+                await Handlers.BodyJson(JsonSerializer.Serialize(result.Body))(context);
+                return result.Base;
+            });
+
+        private bool ParseInput<TInput>(IRequestContext context, out TInput result)
+        {
+            try
+            {
+                result = JsonSerializer.Deserialize<TInput>(context.RequestInfo.Body);
+                return true;
+            }
+            catch (JsonException)
+            {
+                result = default(TInput);
+                return false;
+            }
+        }
+    }
+}
+#endif

--- a/src/LaunchDarkly.TestHelpers/HttpTest/SimpleJsonService.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/SimpleJsonService.cs
@@ -1,9 +1,7 @@
-﻿#if !NET452
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace LaunchDarkly.TestHelpers.HttpTest
 {   
@@ -32,8 +30,12 @@ namespace LaunchDarkly.TestHelpers.HttpTest
     /// containing parentheses is assumed to be a regex, otherwise it is taken as a literal.
     /// </para>
     /// <para>
-    /// Because this class uses <code>System.Text.Json</code>, it is not available in .NET
-    /// Framework 4.5.x.
+    /// This class uses <code>Newtonsoft.Json</code> for JSON conversions, rather than
+    /// <c>System.Text.Json</c>. This is because it needs to be usable from projects that support
+    /// .NET Framework 4.5.x, and <c>System.Text.Json</c> is not available in that framework.
+    /// Since the <code>Newtonsoft.Json</code> API uses static methods for configuration, it is
+    /// the host application's responsibility to make sure it has been configured to produce the
+    /// expected behavior for the types that are being used.
     /// </para>
     /// </remarks>
     public sealed class SimpleJsonService
@@ -208,7 +210,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 var result = await handler(context);
                 if (typeof(TOutput).IsValueType || !result.Body.Equals(default(TOutput)))
                 {
-                    await Handlers.BodyJson(JsonSerializer.Serialize(result.Body))(context);
+                    await Handlers.BodyJson(JsonConvert.SerializeObject(result.Body))(context);
                 }
                 return result.Base;
             });
@@ -221,7 +223,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                     return SimpleResponse.Of(400);
                 }
                 var result = await handler(context, input);
-                await Handlers.BodyJson(JsonSerializer.Serialize(result.Body))(context);
+                await Handlers.BodyJson(JsonConvert.SerializeObject(result.Body))(context);
                 return result.Base;
             });
 
@@ -229,7 +231,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         {
             try
             {
-                result = JsonSerializer.Deserialize<TInput>(context.RequestInfo.Body);
+                result = JsonConvert.DeserializeObject<TInput>(context.RequestInfo.Body);
                 return true;
             }
             catch (JsonException)
@@ -240,4 +242,3 @@ namespace LaunchDarkly.TestHelpers.HttpTest
         }
     }
 }
-#endif

--- a/src/LaunchDarkly.TestHelpers/HttpTest/SimpleResponse.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/SimpleResponse.cs
@@ -1,5 +1,4 @@
-﻿#if !NET452
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace LaunchDarkly.TestHelpers.HttpTest
 {
@@ -139,4 +138,3 @@ namespace LaunchDarkly.TestHelpers.HttpTest
             new SimpleResponse<T>(Base.WithHeader(key, value), Body);
     }
 }
-#endif

--- a/src/LaunchDarkly.TestHelpers/HttpTest/SimpleResponse.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/SimpleResponse.cs
@@ -1,0 +1,142 @@
+﻿#if !NET452
+using System.Collections.Generic;
+
+namespace LaunchDarkly.TestHelpers.HttpTest
+{
+    /// <summary>
+    /// Return type for endpoint handlers with <see cref="SimpleJsonService"/>.
+    /// </summary>
+    public struct SimpleResponse
+    {
+        private static KeyValuePair<string, IEnumerable<string>>[] _empty =
+            new KeyValuePair<string, IEnumerable<string>>[0];
+
+        /// <summary>
+        /// The HTTP status code.
+        /// </summary>
+        public int Status { get; private set; }
+        private readonly Dictionary<string, List<string>> _headers;
+
+        /// <summary>
+        /// An enumeration of header keys and values.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, IEnumerable<string>>> Headers
+        {
+            get
+            {
+                if (_headers is null)
+                {
+                    return _empty;
+                }
+                var ret = new Dictionary<string, IEnumerable<string>>();
+                foreach (var kv in _headers)
+                {
+                    ret.Add(kv.Key, kv.Value);
+                }
+                return ret;
+            }
+        }
+
+        private SimpleResponse(int status, Dictionary<string, List<string>> headers)
+        {
+            Status = status;
+            _headers = headers;
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="SimpleResponse"/> with an HTTP status code.
+        /// </summary>
+        /// <param name="status">the status code</param>
+        /// <returns>a <see cref="SimpleResponse"/></returns>
+        public static SimpleResponse Of(int status) =>
+            new SimpleResponse(status, null);
+
+        /// <summary>
+        /// Constructs a <see cref="SimpleResponse"/> with an HTTP status code and a
+        /// serializable response body.
+        /// </summary>
+        /// <param name="status">the status code</param>
+        /// <param name="body">the value to serialize</param>
+        /// <typeparam name="T">the value type</typeparam>
+        /// <returns>a <see cref="SimpleResponse"/></returns>
+        public static SimpleResponse<T> Of<T>(int status, T body) =>
+            SimpleResponse<T>.Of(status, body);
+
+        /// <summary>
+        /// Copies this response and adds a header key and value.
+        /// </summary>
+        /// <param name="key">a header key</param>
+        /// <param name="value">a header value</param>
+        /// <returns>a <see cref="SimpleResponse"/></returns>
+        public SimpleResponse WithHeader(string key, string value)
+        {
+            var newDict = new Dictionary<string, List<string>>();
+            var found = false;
+            if (_headers != null)
+            {
+                foreach (var kv in _headers)
+                {
+                    if (kv.Key.ToLower() == key.ToLower())
+                    {
+                        var values = new List<string>(kv.Value);
+                        values.Add(value);
+                        newDict[kv.Key] = values;
+                        found = true;
+                    }
+                    else
+                    {
+                        newDict[kv.Key] = kv.Value;
+                    }
+                }
+            }
+            if (!found)
+            {
+                newDict[key] = new List<string> { value };
+            }
+            return new SimpleResponse(Status, newDict);
+        }
+    }
+
+    /// <summary>
+    /// Return type for endpoint handlers with <see cref="SimpleJsonService"/>, when they
+    /// return a value to be serialized as a response body.
+    /// </summary>
+    public struct SimpleResponse<T>
+    {
+        /// <summary>
+        /// The basic response properties.
+        /// </summary>
+        public SimpleResponse Base { get; private set; }
+
+        /// <summary>
+        /// The value to serialize as the response.
+        /// </summary>
+        public T Body { get; private set; }
+
+        private SimpleResponse(SimpleResponse baseResp, T body)
+        {
+            Base = baseResp;
+            Body = body;
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="SimpleResponse{T}"/> with an HTTP status code and a
+        /// serializable response body.
+        /// </summary>
+        /// <param name="status">the status code</param>
+        /// <param name="value">the value to serialize</param>
+        /// <returns>a <see cref="SimpleResponse{T}"/></returns>
+        public static SimpleResponse<T> Of(int status, T value) =>
+            new SimpleResponse<T>(SimpleResponse.Of(status), value);
+
+        /// <summary>
+        /// Copies this response and adds a header key and value.
+        /// </summary>
+        /// <param name="key">a header key</param>
+        /// <param name="value">a header value</param>
+        /// <returns>a <see cref="SimpleResponse{T}"/></returns>
+        public SimpleResponse<T> WithHeader(string key, string value) =>
+            new SimpleResponse<T>(Base.WithHeader(key, value), Body);
+    }
+}
+#endif

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -34,24 +34,24 @@
                          '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or
                          '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup>
     <None Remove="xunit" />
     <None Remove="Newtonsoft.Json" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
+
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.TestHelpers.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>1.3.0</Version>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net452;net461</TargetFrameworks>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <AssemblyName>LaunchDarkly.TestHelpers</AssemblyName>
     <DebugType>portable</DebugType>
@@ -27,6 +27,12 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or&#xA;                         '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -34,7 +34,7 @@
                          '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -37,11 +37,6 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or
-                         '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="System.Text.Json" Version="5.0.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Remove="xunit" />
     <None Remove="Newtonsoft.Json" />

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -1,8 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.3.0</Version>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net452;net461</TargetFrameworks>
+    <Version>1.4.0-alpha.1</Version>
+    <!-- The BUILDFRAMEWORKS variable allows us to override the target frameworks with a
+         single framework that we are testing; this allows us to test with older SDK
+         versions that would error out if they saw any newer target frameworks listed
+         here, even if we weren't running those. -->
+    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp3.1;net452;net461</BuildFrameworks>
+    <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <AssemblyName>LaunchDarkly.TestHelpers</AssemblyName>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -30,13 +30,15 @@
     <WarningsAsErrors>1570,1571,1572,1573,1574,1580,1581,1584,1591,1710,1711,1712</WarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' or
+                         '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or&#xA;                         '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or
+                         '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/HttpServerTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/HttpServerTest.cs
@@ -93,5 +93,19 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 Assert.Contains("deliberately broken", body);
             });
         }
+
+        [Fact]
+        public async Task ServerCanAcceptManyRequests()
+        {
+            await WithServerAndClient(Handlers.Status(200), async (server, client) =>
+            {
+                server.Recorder.Enabled = false;
+                for (var i = 0; i < 2000; i++)
+                {
+                    var resp = await client.GetAsync(server.Uri);
+                    Assert.Equal(200, (int)resp.StatusCode);
+                }
+            });
+        }
     }
 }

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/RequestRecorderTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/RequestRecorderTest.cs
@@ -71,5 +71,33 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 Assert.Equal("hello", received.Body);
             });
         }
+
+        [Fact]
+        public async Task RecordingCanBeDisabled()
+        {
+            await WithServerAndClient(Handlers.Status(200), async (server, client) =>
+            {
+                var req1 = new HttpRequestMessage(HttpMethod.Get, new Uri(server.Uri, "/path1"));
+                await client.SendAsync(req1);
+
+                server.Recorder.Enabled = false;
+
+                var req2 = new HttpRequestMessage(HttpMethod.Get, new Uri(server.Uri, "/path2"));
+                await client.SendAsync(req2);
+
+                server.Recorder.Enabled = true;
+
+                var req3 = new HttpRequestMessage(HttpMethod.Get, new Uri(server.Uri, "/path3"));
+                await client.SendAsync(req3);
+
+                var received1 = server.Recorder.RequireRequest();
+                Assert.Equal("/path1", received1.Path);
+
+                var received3 = server.Recorder.RequireRequest();
+                Assert.Equal("/path3", received3.Path);
+
+                server.Recorder.RequireNoRequests(TimeSpan.Zero);
+            });
+        }
     }
 }

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SimpleJsonServiceTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SimpleJsonServiceTest.cs
@@ -1,0 +1,161 @@
+﻿#if !NET452
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+using static LaunchDarkly.TestHelpers.HttpTest.TestUtil;
+
+namespace LaunchDarkly.TestHelpers.HttpTest
+{
+    public class SimpleJsonServiceTest
+    {
+        [Fact]
+        public async void NoPathsMatchByDefault() =>
+            await WithServerAndClient(new SimpleJsonService(), async (server, client) =>
+            {
+                var resp = await client.GetAsync(server.Uri);
+                Assert.Equal(404, (int)resp.StatusCode);
+            });
+
+        [Fact]
+        public async void SimpleEndpoint()
+        {
+            var received = new EventSink<bool>();
+            var service = new SimpleJsonService();
+            service.Route(HttpMethod.Post, "/path", context =>
+            {
+                received.Enqueue(true);
+                return SimpleResponse.Of(202);
+            });
+            await WithServerAndClient(service, async (server, client) =>
+            {
+                var resp = await client.PostAsync(new Uri(server.Uri, "/path"), null);
+                Assert.Equal(202, (int)resp.StatusCode);
+                received.ExpectValue();
+            });
+        }
+
+        [Fact]
+        public async void EndpointWithJsonInput()
+        {
+            var received = new EventSink<JsonParams>();
+            var service = new SimpleJsonService();
+            service.Route(HttpMethod.Post, "/path", (IRequestContext context, JsonParams p) =>
+            {
+                received.Enqueue(p);
+                return SimpleResponse.Of(202);
+            });
+            await WithServerAndClient(service, async (server, client) =>
+            {
+                var resp = await client.PostAsync(new Uri(server.Uri, "/path"),
+                    new StringContent(@"{""number"":1,""name"":""a""}", Encoding.UTF8, "application/json"));
+                Assert.Equal(202, (int)resp.StatusCode);
+                var p = received.ExpectValue();
+                Assert.Equal(1, p.Number);
+                Assert.Equal("a", p.Name);
+            });
+        }
+
+        [Fact]
+        public async void EndpointWithJsonInputBadRequest()
+        {
+            var received = new EventSink<JsonParams>();
+            var service = new SimpleJsonService();
+            service.Route(HttpMethod.Post, "/path", (IRequestContext context, JsonParams p) =>
+            {
+                received.Enqueue(p);
+                return SimpleResponse.Of(202);
+            });
+            await WithServerAndClient(service, async (server, client) =>
+            {
+                var resp = await client.PostAsync(new Uri(server.Uri, "/path"),
+                    new StringContent(@"{""no", Encoding.UTF8, "application/json"));
+                Assert.Equal(400, (int)resp.StatusCode);
+                received.ExpectNoValue();
+            });
+        }
+
+        [Fact]
+        public async void EndpointWithJsonOutput()
+        {
+            var service = new SimpleJsonService();
+            service.Route<JsonParams>(HttpMethod.Get, "/path", context =>
+            {
+                return SimpleResponse.Of(200, new JsonParams { Number = 1, Name = "a" });
+            });
+            await WithServerAndClient(service, async (server, client) =>
+            {
+                var resp = await client.GetAsync(new Uri(server.Uri, "/path"));
+                Assert.Equal(200, (int)resp.StatusCode);
+                var p = JsonSerializer.Deserialize<JsonParams>(await resp.Content.ReadAsStringAsync());
+                Assert.Equal(1, p.Number);
+                Assert.Equal("a", p.Name);
+            });
+        }
+
+        [Fact]
+        public async void EndpointWithJsonInputAndOutput()
+        {
+            var service = new SimpleJsonService();
+            service.Route<JsonParams, JsonParams>(HttpMethod.Post, "/path", (IRequestContext context, JsonParams p) =>
+            {
+                return SimpleResponse.Of(200, new JsonParams { Number = p.Number + 1, Name = p.Name + "b" });
+            });
+            await WithServerAndClient(service, async (server, client) =>
+            {
+                var resp = await client.PostAsync(new Uri(server.Uri, "/path"),
+                    new StringContent(@"{""number"":1,""name"":""a""}", Encoding.UTF8, "application/json"));
+                Assert.Equal(200, (int)resp.StatusCode);
+                var p = JsonSerializer.Deserialize<JsonParams>(await resp.Content.ReadAsStringAsync());
+                Assert.Equal(2, p.Number);
+                Assert.Equal("ab", p.Name);
+            });
+        }
+
+        [Fact]
+        public async void EndpointWithJsonInputAndOutputBadRequest()
+        {
+            var received = new EventSink<JsonParams>();
+            var service = new SimpleJsonService();
+            service.Route<JsonParams, JsonParams>(HttpMethod.Post, "/path", (IRequestContext context, JsonParams p) =>
+            {
+                received.Enqueue(p);
+                return SimpleResponse.Of(200, new JsonParams { Number = p.Number + 1, Name = p.Name + "b" });
+            });
+            await WithServerAndClient(service, async (server, client) =>
+            {
+                var resp = await client.PostAsync(new Uri(server.Uri, "/path"),
+                    new StringContent(@"{""no", Encoding.UTF8, "application/json"));
+                Assert.Equal(400, (int)resp.StatusCode);
+                received.ExpectNoValue();
+            });
+        }
+
+        [Fact]
+        public async void EndpointCanReturnHeaders()
+        {
+            var service = new SimpleJsonService();
+            service.Route(HttpMethod.Post, "/path", context =>
+            {
+                return SimpleResponse.Of(201).WithHeader("Location", "http://somewhere/");
+            });
+            await WithServerAndClient(service, async (server, client) =>
+            {
+                var resp = await client.PostAsync(new Uri(server.Uri, "/path"), null);
+                Assert.Equal(201, (int)resp.StatusCode);
+                Assert.Equal("http://somewhere/", resp.Headers.Location.ToString());
+            });
+        }
+
+        sealed class JsonParams
+        {
+            [JsonPropertyName("number")] public int Number { get; set; }
+            [JsonPropertyName("name")] public string Name { get; set; }
+        }
+    }
+}
+#endif

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SimpleJsonServiceTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SimpleJsonServiceTest.cs
@@ -1,10 +1,8 @@
-﻿#if !NET452
-using System;
+﻿using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Xunit;
 
 using static LaunchDarkly.TestHelpers.HttpTest.TestUtil;
@@ -91,7 +89,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
             {
                 var resp = await client.GetAsync(new Uri(server.Uri, "/path"));
                 Assert.Equal(200, (int)resp.StatusCode);
-                var p = JsonSerializer.Deserialize<JsonParams>(await resp.Content.ReadAsStringAsync());
+                var p = JsonConvert.DeserializeObject<JsonParams>(await resp.Content.ReadAsStringAsync());
                 Assert.Equal(1, p.Number);
                 Assert.Equal("a", p.Name);
             });
@@ -110,7 +108,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 var resp = await client.PostAsync(new Uri(server.Uri, "/path"),
                     new StringContent(@"{""number"":1,""name"":""a""}", Encoding.UTF8, "application/json"));
                 Assert.Equal(200, (int)resp.StatusCode);
-                var p = JsonSerializer.Deserialize<JsonParams>(await resp.Content.ReadAsStringAsync());
+                var p = JsonConvert.DeserializeObject<JsonParams>(await resp.Content.ReadAsStringAsync());
                 Assert.Equal(2, p.Number);
                 Assert.Equal("ab", p.Name);
             });
@@ -171,9 +169,8 @@ namespace LaunchDarkly.TestHelpers.HttpTest
 
         sealed class JsonParams
         {
-            [JsonPropertyName("number")] public int Number { get; set; }
-            [JsonPropertyName("name")] public string Name { get; set; }
+            public int Number { get; set; }
+            public string Name { get; set; }
         }
     }
 }
-#endif

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SimpleJsonServiceTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SimpleJsonServiceTest.cs
@@ -151,6 +151,24 @@ namespace LaunchDarkly.TestHelpers.HttpTest
             });
         }
 
+        [Fact]
+        public async void EndpointGetsPathParam()
+        {
+            var received = new EventSink<string>();
+            var service = new SimpleJsonService();
+            service.Route(HttpMethod.Post, "/path/([^/]*)/please", context =>
+            {
+                received.Enqueue(context.GetPathParam(0));
+                return SimpleResponse.Of(202);
+            });
+            await WithServerAndClient(service, async (server, client) =>
+            {
+                var resp = await client.PostAsync(new Uri(server.Uri, "/path/thing/please"), null);
+                Assert.Equal(202, (int)resp.StatusCode);
+                Assert.Equal("thing", received.ExpectValue());
+            });
+        }
+
         sealed class JsonParams
         {
             [JsonPropertyName("number")] public int Number { get; set; }

--- a/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SimpleRouterTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/HttpTest/SimpleRouterTest.cs
@@ -91,5 +91,25 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                 var resp4 = await client.DeleteAsync(new Uri(server.Uri, "/path3"));
                 Assert.Equal(404, (int)resp4.StatusCode);
             });
+
+        [Fact]
+        public async void PathRegexMatchCapturingParams() =>
+            await WithServerAndClient(Handlers.Router(out var router), async (server, client) =>
+            {
+                string param1 = null, param2 = null;
+                Handler handler = async ctx =>
+                {
+                    param1 = ctx.GetPathParam(0);
+                    param2 = ctx.GetPathParam(1);
+                    await Handlers.Status(200)(ctx);
+                };
+                router.AddRegex("/path/([^/]*)/(.*)", handler);
+
+                var resp = await client.GetAsync(new Uri(server.Uri, "/path/for/me"));
+                Assert.Equal(200, (int)resp.StatusCode);
+
+                Assert.Equal("for", param1);
+                Assert.Equal("me", param2);
+            });
     }
 }

--- a/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+++ b/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
@@ -18,7 +18,8 @@
     <ProjectReference Include="..\..\src\LaunchDarkly.TestHelpers\LaunchDarkly.TestHelpers.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' or
+                         '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
In small web services that are used for testing, we've been using ASP.NET Core as a framework. But that means we can't run it in Windows, and it's a pain to have to maintain a parallel ASP.NET implementation. This is an issue for dotnet-server-restwrapper, and for the contract test services for dotnet-server-sdk and dotnet-eventsource.

We already have a very basic embedded HTTP server tool in `dotnet-test-helpers`, based on fully portable .NET APIs, that's used in unit tests. This could probably be adequate for our test service needs with a few changes, which I've made here:

* You can now start the server on a specific port, as opposed to using whatever port is available as we normally do in unit tests.
* You can turn off the default behavior of recording all requests.
* There's a simple mechanism for getting path parameters (based on a similar feature in https://github.com/launchdarkly/java-test-helpers).
* The `SimpleJsonService` class provides a quick way to implement a set of service endpoints with automatic JSON conversion of parameter/response types. The same things can be done with the existing API, but this is nicer.

That should be all we need to implement a service that would work in both .NET Core and .NET Framework.