### PR TITLE
drop EOL target frameworks and don't use Newtonsoft.Json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,24 +7,23 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-netcore:
-      - test-netcore:
+      - test_linux:
           name: .NET Core 3.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
           build-target-framework: netcoreapp3.1
           test-target-framework: netcoreapp3.1
-      - test-netcore:
+      - test_linux:
           name: .NET 6.0
           docker-image: mcr.microsoft.com/dotnet/sdk:6.0-focal
           build-target-framework: net6.0
           test-target-framework: net5.0
-      - test-windows-netframework:
+      - test_windows:
           name: .NET Framework 4.6.2
           build-target-framework: net462
           test-target-framework: net462
 
 jobs:
-  test-netcore:
+  test_linux:
     parameters:
       docker-image:
         type: string
@@ -43,7 +42,7 @@ jobs:
       - run: dotnet build src/LaunchDarkly.TestHelpers
       - run: dotnet test test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
 
-  test-windows-netframework:
+  test_windows:
     parameters:
       build-target-framework:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,28 +8,20 @@ workflows:
   test:
     jobs:
       - test-netcore:
-          name: .NET Core 2.1
-          docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
-          build-target-framework: netstandard2.0
-          test-target-framework: netcoreapp2.1
       - test-netcore:
           name: .NET Core 3.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
           build-target-framework: netcoreapp3.1
           test-target-framework: netcoreapp3.1
       - test-netcore:
-          name: .NET 5.0
-          docker-image: mcr.microsoft.com/dotnet/sdk:5.0-focal
-          build-target-framework: netstandard2.0
+          name: .NET 6.0
+          docker-image: mcr.microsoft.com/dotnet/sdk:6.0-focal
+          build-target-framework: net6.0
           test-target-framework: net5.0
       - test-windows-netframework:
-          name: .NET Framework 4.5.2
-          build-target-framework: net452
-          test-target-framework: net452
-      - test-windows-netframework:
-          name: .NET Framework 4.6.1
-          build-target-framework: net461
-          test-target-framework: net461
+          name: .NET Framework 4.6.2
+          build-target-framework: net462
+          test-target-framework: net462
 
 jobs:
   test-netcore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,17 @@ jobs:
       TESTFRAMEWORK: <<parameters.test-target-framework>>
     steps:
       - checkout
-      - run: dotnet build src/LaunchDarkly.TestHelpers
-      - run: dotnet test test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+      - run:
+          name: build
+          command: dotnet build src/LaunchDarkly.TestHelpers
+      - run:
+          name: run tests
+          command: |
+            dotnet test \
+              --logger:"junit;LogFilePath=/tmp/circle-reports/unit-tests.xml" \
+              test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+      - store_test_results:
+          path: /tmp/circle-reports
 
   test_windows:
     parameters:
@@ -56,5 +65,14 @@ jobs:
       TESTFRAMEWORK: <<parameters.test-target-framework>>
     steps:
       - checkout
-      - run: dotnet build src/LaunchDarkly.TestHelpers
-      - run: dotnet test test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+      - run:
+          name: build
+          command: dotnet build src/LaunchDarkly.TestHelpers
+      - run:
+          name: run tests
+          command: |
+            dotnet test \
+              --logger:"junit;LogFilePath=/tmp/circle-reports/unit-tests.xml" \
+              test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+      - store_test_results:
+          path: /tmp/circle-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
           name: .NET 6.0
           docker-image: mcr.microsoft.com/dotnet/sdk:6.0-focal
           build-target-framework: net6.0
-          test-target-framework: net5.0
+          test-target-framework: net6.0
       - test_windows:
           name: .NET Framework 4.6.2
           build-target-framework: net462

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           name: run tests
           command: |
             dotnet test \
-              --logger:"junit;LogFilePath=/tmp/circle-reports/unit-tests.xml" \
+              -l "junit;LogFilePath=/tmp/circle-reports/unit-tests.xml" \
               test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
       - store_test_results:
           path: /tmp/circle-reports

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -7,10 +7,14 @@ publications:
 jobs:
   - docker: {}
     template:
-      name: dotnet-linux
+      name: dotnet6-linux
     env:
-      LD_RELEASE_TEST_TARGET_FRAMEWORK: net50
+      LD_RELEASE_TEST_TARGET_FRAMEWORK: net6.0
       LD_RELEASE_DOCS_TARGET_FRAMEWORK: netstandard2.0
+
+branches:
+  - name: main
+  - name: 1.x
 
 documentation:
   gitHubPages: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We encourage pull requests and other contributions from the community. Before su
  
 ### Prerequisites
 
-To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 5.0 is preferred, since the .NET 5.0 tools are able to build for all supported target platforms.
+To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 6.0 is preferred, since the .NET 6.0 tools are able to build for all supported target platforms.
 
 ### Building
  
@@ -44,8 +44,8 @@ To run all unit tests, for all targets:
 dotnet test test/LaunchDarkly.TestHelpers.Tests
 ```
 
-Or, to run tests only for the .NET Standard 2.0 target (using the .NET Core 2.1 runtime):
+Or, to run tests only for the .NET Standard 2.0 target (using the .NET Core 3.1 runtime):
 
 ```
-dotnet test test/LaunchDarkly.TestHelpers.Tests -f netcoreapp2.1
+dotnet test test/LaunchDarkly.TestHelpers.Tests -f netcoreapp3.1
 ```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ See [API documentation](https://launchdarkly.github.io/dotnet-test-helpers) for 
 
 This version of the project is built for two target frameworks:
 
-* .NET Standard 2.0: Usable in .NET Core 2+, .NET 5+, and Xamarin.
-* .NET Framework 4.5.2: Usable in .NET Framework 4.5.2 and above.
+* .NET Standard 2.0 (usable in Xamarin).
+* .NET Core 3.1.
+* .NET Framework 4.6.2 (usable in all higher versions of .NET Framework).
+* .NET 6.0 (usable in all higher versions of .NET).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [API documentation](https://launchdarkly.github.io/dotnet-test-helpers) for 
 
 ## Compatibility
 
-This version of the project is built for two target frameworks:
+This version of the project is built for the following target frameworks:
 
 * .NET Standard 2.0 (usable in Xamarin).
 * .NET Core 3.1.

--- a/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
+++ b/src/LaunchDarkly.TestHelpers/HttpTest/HttpServer.cs
@@ -155,7 +155,7 @@ namespace LaunchDarkly.TestHelpers.HttpTest
                                 });
 #pragma warning restore CS4014
                         }
-                        catch(Exception e)
+                        catch (Exception)
                         {
                             // an exception almost certainly means the listener has been shut down
                             break;

--- a/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
+++ b/src/LaunchDarkly.TestHelpers/LaunchDarkly.TestHelpers.csproj
@@ -6,7 +6,7 @@
          single framework that we are testing; this allows us to test with older SDK
          versions that would error out if they saw any newer target frameworks listed
          here, even if we weren't running those. -->
-    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp3.1;net452;net461</BuildFrameworks>
+    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp3.1;net462;net6.0</BuildFrameworks>
     <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <AssemblyName>LaunchDarkly.TestHelpers</AssemblyName>
@@ -30,8 +30,7 @@
     <WarningsAsErrors>1570,1571,1572,1573,1574,1580,1581,1584,1591,1710,1711,1712</WarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' or
-                         '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
@@ -39,14 +38,18 @@
 
   <ItemGroup>
     <None Remove="xunit" />
-    <None Remove="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'
+                       or '$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <!-- it's a built-in package in netcoreapp3.1 and net6.0 -->
+  </ItemGroup>
+  
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.TestHelpers.xml</DocumentationFile>
   </PropertyGroup>

--- a/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
@@ -78,7 +78,7 @@ namespace LaunchDarkly.TestHelpers
                 var jsonActual = JsonTestValue.JsonOf(actual);
                 Assert.NotEqual(jsonExpected, jsonActual);
             }
-            catch (FormatException e)
+            catch (FormatException)
             {
                 // if this was a test of deliberately malformed JSON, then skip the Assert.NotEqual test
             }

--- a/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
@@ -22,6 +22,8 @@ namespace LaunchDarkly.TestHelpers
             JsonAssertions.AssertJsonEqual(expected, actual);
             JsonAssertions.AssertJsonEqual(actual, expected);
             JsonAssertions.AssertJsonEqual(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
+
+            Assert.Equal(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
         }
 
         [Fact]
@@ -69,6 +71,8 @@ namespace LaunchDarkly.TestHelpers
             ShouldFailWithMessage(expectedMessage, () => JsonAssertions.AssertJsonEqual(expected, actual));
             ShouldFailWithMessage(expectedMessage, () => JsonAssertions.AssertJsonEqual(
                 JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual)));
+
+            Assert.NotEqual(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
         }
 
         [Fact]

--- a/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
+++ b/test/LaunchDarkly.TestHelpers.Tests/JsonAssertionsTest.cs
@@ -72,7 +72,16 @@ namespace LaunchDarkly.TestHelpers
             ShouldFailWithMessage(expectedMessage, () => JsonAssertions.AssertJsonEqual(
                 JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual)));
 
-            Assert.NotEqual(JsonTestValue.JsonOf(expected), JsonTestValue.JsonOf(actual));
+            try
+            {
+                var jsonExpected = JsonTestValue.JsonOf(expected);
+                var jsonActual = JsonTestValue.JsonOf(actual);
+                Assert.NotEqual(jsonExpected, jsonActual);
+            }
+            catch (FormatException e)
+            {
+                // if this was a test of deliberately malformed JSON, then skip the Assert.NotEqual test
+            }
         }
 
         [Fact]

--- a/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+++ b/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
@@ -25,8 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 
 </Project>

--- a/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+++ b/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
@@ -5,7 +5,7 @@
          single framework that we are testing; this allows us to test with older .NET SDK
          versions that would error out if they saw any newer target frameworks listed
          here, even if we weren't running those. -->
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.1;net452;net5.0</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp3.1;net462;net6.0</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
     <AssemblyName>LaunchDarkly.TestHelpers.Tests</AssemblyName>
     <PackageId>LaunchDarkly.TestHelpers.Tests</PackageId>
@@ -18,8 +18,7 @@
     <ProjectReference Include="..\..\src\LaunchDarkly.TestHelpers\LaunchDarkly.TestHelpers.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' or
-                         '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />

--- a/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
+++ b/test/LaunchDarkly.TestHelpers.Tests/LaunchDarkly.TestHelpers.Tests.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.114" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Now that we don't need .NET Framework 4.5.2, we can assume System.Text.Json is available and rely on it for all the JSON-related test stuff, instead of bringing in Newtonsoft.

This will be a major version bump for LaunchDarkly.TestHelpers.